### PR TITLE
Fix template tests on actions

### DIFF
--- a/src/template.rs
+++ b/src/template.rs
@@ -113,6 +113,8 @@ pub struct TemplateManager {
 
 impl TemplateManager {
     pub fn new(config: &ConfigManager) -> Result<Self> {
+        // Ensure config directory exists before creating subdirectories
+        config.ensure_config_dir()?;
         let templates_dir = config.ensure_subdir("templates")?;
 
         let mut manager = Self {
@@ -164,6 +166,12 @@ impl TemplateManager {
 
         let filename = format!("template_{}.json", template.id);
         let file_path = self.templates_dir.join(filename);
+
+        // Ensure the parent directory exists right before opening the file
+        // This handles edge cases where the directory might not exist despite checks above
+        if let Some(parent) = file_path.parent() {
+            fs::create_dir_all(parent)?;
+        }
 
         let json = serde_json::to_string_pretty(template)?;
 


### PR DESCRIPTION
Ensures the template directory (and parents) exist before attempting to write.