### PR TITLE
Add option passing to datui.view

### DIFF
--- a/crates/datui-pyo3/Cargo.lock
+++ b/crates/datui-pyo3/Cargo.lock
@@ -1159,14 +1159,14 @@ dependencies = [
 
 [[package]]
 name = "datui-cli"
-version = "0.2.42-dev"
+version = "0.2.47-dev"
 dependencies = [
  "clap",
 ]
 
 [[package]]
 name = "datui-lib"
-version = "0.2.42-dev"
+version = "0.2.47-dev"
 dependencies = [
  "arrow",
  "bzip2",
@@ -1201,7 +1201,7 @@ dependencies = [
 
 [[package]]
 name = "datui-pyo3"
-version = "0.2.42-dev"
+version = "0.2.47-dev"
 dependencies = [
  "bincode",
  "datui-lib",

--- a/crates/datui-pyo3/src/lib.rs
+++ b/crates/datui-pyo3/src/lib.rs
@@ -1,20 +1,318 @@
 //! Python bindings for datui. Exposes `view_from_bytes` (binary-serialized LazyFrame),
 //! `view_from_json` (JSON, deprecated by Polars), `view_paths` (open by path strings),
-//! and `run_cli`. The Python package provides `view()` which accepts LazyFrame/DataFrame
-//! or path string(s) and dispatches accordingly.
+//! `DatuiOptions`, `CompressionFormat`, and `run_cli`. The Python package provides
+//! `view()` which accepts LazyFrame/DataFrame or path string(s) and dispatches accordingly.
 //!
 //! Error classification lives in datui-lib; the binding only maps lib result to Python exceptions.
 
 use std::panic;
 use std::path::{Path, PathBuf};
 
-use ::datui::{error_for_python, ErrorKindForPython, OpenOptions, RunInput, run};
+use ::datui::{error_for_python, CompressionFormat, ErrorKindForPython, OpenOptions, RunInput, run};
 use bincode::config::legacy;
 use polars::prelude::LazyFrame;
 use polars_plan::dsl::DslPlan;
-use pyo3::exceptions::{PyFileNotFoundError, PyPermissionError, PyRuntimeError, PyValueError};
+use pyo3::exceptions::{PyFileNotFoundError, PyPermissionError, PyRuntimeError, PyTypeError, PyValueError};
 use pyo3::prelude::*;
 use serde_json::{self, Value};
+
+fn parse_compression(s: &str) -> PyResult<CompressionFormat> {
+    match s.to_lowercase().as_str() {
+        "gzip" => Ok(CompressionFormat::Gzip),
+        "zstd" | "zstandard" => Ok(CompressionFormat::Zstd),
+        "bzip2" | "bz2" => Ok(CompressionFormat::Bzip2),
+        "xz" => Ok(CompressionFormat::Xz),
+        _ => Err(PyValueError::new_err(format!(
+            "compression must be one of: gzip, zstd, bzip2, xz (got {:?})",
+            s
+        ))),
+    }
+}
+
+fn delimiter_from_py(any: &Bound<'_, pyo3::types::PyAny>) -> PyResult<Option<u8>> {
+    if any.is_none() {
+        return Ok(None);
+    }
+    if let Ok(n) = any.extract::<i64>() {
+        let b = u8::try_from(n).map_err(|_| {
+            PyValueError::new_err(format!("delimiter must be 0-255 (got {})", n))
+        })?;
+        return Ok(Some(b));
+    }
+    if let Ok(s) = any.extract::<String>() {
+        let ch: Vec<char> = s.chars().collect();
+        if ch.len() != 1 {
+            return Err(PyValueError::new_err(
+                "delimiter as str must be a single character",
+            ));
+        }
+        let b = ch[0] as u32;
+        if b > 255 {
+            return Err(PyValueError::new_err(
+                "delimiter character code must be 0-255",
+            ));
+        }
+        return Ok(Some(b as u8));
+    }
+    Err(PyTypeError::new_err(
+        "delimiter must be int (0-255) or single-character str",
+    ))
+}
+
+fn opt_path_from_py(any: Option<&Bound<'_, pyo3::types::PyAny>>) -> PyResult<Option<PathBuf>> {
+    let Some(any) = any else { return Ok(None) };
+    if any.is_none() {
+        return Ok(None);
+    }
+    let s: String = any.extract().map_err(|_| {
+        PyTypeError::new_err("temp_dir must be str or path-like")
+    })?;
+    Ok(Some(PathBuf::from(s)))
+}
+
+/// Options for loading and displaying data in the TUI (Python name for OpenOptions).
+#[pyclass(name = "DatuiOptions")]
+struct DatuiOptionsPy {
+    inner: OpenOptions,
+}
+
+#[pymethods]
+impl DatuiOptionsPy {
+    #[new]
+    #[pyo3(signature = (
+        delimiter=None,
+        has_header=None,
+        skip_lines=None,
+        skip_rows=None,
+        compression=None,
+        pages_lookahead=None,
+        pages_lookback=None,
+        max_buffered_rows=None,
+        max_buffered_mb=None,
+        row_numbers=false,
+        row_start_index=1,
+        hive=false,
+        single_spine_schema=true,
+        parse_dates=true,
+        decompress_in_memory=false,
+        temp_dir=None,
+        excel_sheet=None,
+        s3_endpoint_url=None,
+        s3_access_key_id=None,
+        s3_secret_access_key=None,
+        s3_region=None,
+        polars_streaming=true,
+        workaround_pivot_date_index=true,
+        null_values=None,
+        debug=false
+    ))]
+    #[allow(clippy::too_many_arguments)]
+    fn new(
+        delimiter: Option<Bound<'_, pyo3::types::PyAny>>,
+        has_header: Option<Bound<'_, pyo3::types::PyAny>>,
+        skip_lines: Option<Bound<'_, pyo3::types::PyAny>>,
+        skip_rows: Option<Bound<'_, pyo3::types::PyAny>>,
+        compression: Option<Bound<'_, pyo3::types::PyAny>>,
+        pages_lookahead: Option<Bound<'_, pyo3::types::PyAny>>,
+        pages_lookback: Option<Bound<'_, pyo3::types::PyAny>>,
+        max_buffered_rows: Option<Bound<'_, pyo3::types::PyAny>>,
+        max_buffered_mb: Option<Bound<'_, pyo3::types::PyAny>>,
+        row_numbers: bool,
+        row_start_index: usize,
+        hive: bool,
+        single_spine_schema: bool,
+        parse_dates: bool,
+        decompress_in_memory: bool,
+        temp_dir: Option<Bound<'_, pyo3::types::PyAny>>,
+        excel_sheet: Option<Bound<'_, pyo3::types::PyAny>>,
+        s3_endpoint_url: Option<Bound<'_, pyo3::types::PyAny>>,
+        s3_access_key_id: Option<Bound<'_, pyo3::types::PyAny>>,
+        s3_secret_access_key: Option<Bound<'_, pyo3::types::PyAny>>,
+        s3_region: Option<Bound<'_, pyo3::types::PyAny>>,
+        polars_streaming: bool,
+        workaround_pivot_date_index: bool,
+        null_values: Option<Bound<'_, pyo3::types::PyAny>>,
+        debug: bool,
+    ) -> PyResult<Self> {
+        let mut opts = OpenOptions::new();
+        opts.row_numbers = row_numbers;
+        opts.row_start_index = row_start_index;
+        opts.hive = hive;
+        opts.single_spine_schema = single_spine_schema;
+        opts.parse_dates = parse_dates;
+        opts.decompress_in_memory = decompress_in_memory;
+        opts.polars_streaming = polars_streaming;
+        opts.workaround_pivot_date_index = workaround_pivot_date_index;
+
+        if let Some(ref a) = delimiter {
+            opts.delimiter = delimiter_from_py(a)?;
+        }
+        if let Some(ref a) = has_header {
+            if !a.is_none() {
+                opts.has_header = Some(a.extract()?);
+            }
+        }
+        if let Some(ref a) = skip_lines {
+            if !a.is_none() {
+                opts.skip_lines = Some(a.extract::<usize>()?);
+            }
+        }
+        if let Some(ref a) = skip_rows {
+            if !a.is_none() {
+                opts.skip_rows = Some(a.extract::<usize>()?);
+            }
+        }
+        if let Some(ref a) = compression {
+            if !a.is_none() {
+                let s: String = a.extract().map_err(|_| {
+                    PyTypeError::new_err("compression must be str (e.g. 'gzip', 'zstd')")
+                })?;
+                opts.compression = Some(parse_compression(&s)?);
+            }
+        }
+        if let Some(ref a) = pages_lookahead {
+            if !a.is_none() {
+                opts.pages_lookahead = Some(a.extract::<usize>()?);
+            }
+        }
+        if let Some(ref a) = pages_lookback {
+            if !a.is_none() {
+                opts.pages_lookback = Some(a.extract::<usize>()?);
+            }
+        }
+        if let Some(ref a) = max_buffered_rows {
+            if !a.is_none() {
+                opts.max_buffered_rows = Some(a.extract::<usize>()?);
+            }
+        }
+        if let Some(ref a) = max_buffered_mb {
+            if !a.is_none() {
+                opts.max_buffered_mb = Some(a.extract::<usize>()?);
+            }
+        }
+        if let Some(ref a) = temp_dir {
+            opts.temp_dir = opt_path_from_py(Some(a))?;
+        }
+        if let Some(ref a) = excel_sheet {
+            if !a.is_none() {
+                opts.excel_sheet = Some(a.extract::<String>()?);
+            }
+        }
+        if let Some(ref a) = s3_endpoint_url {
+            if !a.is_none() {
+                opts.s3_endpoint_url_override = Some(a.extract::<String>()?);
+            }
+        }
+        if let Some(ref a) = s3_access_key_id {
+            if !a.is_none() {
+                opts.s3_access_key_id_override = Some(a.extract::<String>()?);
+            }
+        }
+        if let Some(ref a) = s3_secret_access_key {
+            if !a.is_none() {
+                opts.s3_secret_access_key_override = Some(a.extract::<String>()?);
+            }
+        }
+        if let Some(ref a) = s3_region {
+            if !a.is_none() {
+                opts.s3_region_override = Some(a.extract::<String>()?);
+            }
+        }
+        if let Some(ref a) = null_values {
+            if !a.is_none() {
+                opts.null_values = Some(a.extract::<Vec<String>>()?);
+            }
+        }
+        opts.debug = debug;
+        Ok(Self { inner: opts })
+    }
+
+    /// Return options as a dict of Python values (for merging with kwargs). Internal use.
+    fn _as_dict<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, pyo3::types::PyDict>> {
+        use pyo3::types::PyDict;
+        let d = PyDict::new(py);
+        let o = &self.inner;
+        if let Some(v) = o.delimiter {
+            d.set_item("delimiter", v)?;
+        }
+        if let Some(v) = o.has_header {
+            d.set_item("has_header", v)?;
+        }
+        if let Some(v) = o.skip_lines {
+            d.set_item("skip_lines", v)?;
+        }
+        if let Some(v) = o.skip_rows {
+            d.set_item("skip_rows", v)?;
+        }
+        if let Some(ref v) = o.compression {
+            let s = match v {
+                CompressionFormat::Gzip => "gzip",
+                CompressionFormat::Zstd => "zstd",
+                CompressionFormat::Bzip2 => "bzip2",
+                CompressionFormat::Xz => "xz",
+            };
+            d.set_item("compression", s)?;
+        }
+        if let Some(v) = o.pages_lookahead {
+            d.set_item("pages_lookahead", v)?;
+        }
+        if let Some(v) = o.pages_lookback {
+            d.set_item("pages_lookback", v)?;
+        }
+        if let Some(v) = o.max_buffered_rows {
+            d.set_item("max_buffered_rows", v)?;
+        }
+        if let Some(v) = o.max_buffered_mb {
+            d.set_item("max_buffered_mb", v)?;
+        }
+        d.set_item("row_numbers", o.row_numbers)?;
+        d.set_item("row_start_index", o.row_start_index)?;
+        d.set_item("hive", o.hive)?;
+        d.set_item("single_spine_schema", o.single_spine_schema)?;
+        d.set_item("parse_dates", o.parse_dates)?;
+        d.set_item("decompress_in_memory", o.decompress_in_memory)?;
+        if let Some(ref v) = o.temp_dir {
+            d.set_item("temp_dir", v.to_string_lossy().as_ref())?;
+        }
+        if let Some(ref v) = o.excel_sheet {
+            d.set_item("excel_sheet", v.as_str())?;
+        }
+        if let Some(ref v) = o.s3_endpoint_url_override {
+            d.set_item("s3_endpoint_url", v.as_str())?;
+        }
+        if let Some(ref v) = o.s3_access_key_id_override {
+            d.set_item("s3_access_key_id", v.as_str())?;
+        }
+        if let Some(ref v) = o.s3_secret_access_key_override {
+            d.set_item("s3_secret_access_key", v.as_str())?;
+        }
+        if let Some(ref v) = o.s3_region_override {
+            d.set_item("s3_region", v.as_str())?;
+        }
+        d.set_item("polars_streaming", o.polars_streaming)?;
+        d.set_item("workaround_pivot_date_index", o.workaround_pivot_date_index)?;
+        if let Some(ref v) = o.null_values {
+            d.set_item("null_values", v.as_slice())?;
+        }
+        d.set_item("debug", o.debug)?;
+        Ok(d)
+    }
+}
+
+fn datui_options_to_rust(opts: Option<&Bound<'_, DatuiOptionsPy>>) -> OpenOptions {
+    opts.map(|o| o.borrow().inner.clone())
+        .unwrap_or_else(OpenOptions::default)
+}
+
+/// Compression format for data files (e.g. for use with DatuiOptions).
+#[pyclass(name = "CompressionFormat")]
+#[derive(Clone, Copy)]
+enum CompressionFormatPy {
+    Gzip,
+    Zstd,
+    Bzip2,
+    Xz,
+}
 
 /// Rewrite path-like objects from newer Polars JSON format to Rust 0.52 format.
 /// Newer Polars emits `{"inner": "/foo"}` (under "path" or other keys); polars-plan 0.52
@@ -60,12 +358,11 @@ fn normalize_path_value(value: Value) -> Option<Value> {
     Some(Value::Object(m))
 }
 
-fn run_tui(plan: DslPlan, debug: bool) -> PyResult<()> {
+fn run_tui(plan: DslPlan, opts: OpenOptions) -> PyResult<()> {
     let lf = LazyFrame::from(plan);
     let result = panic::catch_unwind(panic::AssertUnwindSafe(|| {
-        let opts = OpenOptions::default();
         let input = RunInput::LazyFrame(Box::new(lf), opts);
-        run(input, None, debug)
+        run(input, None)
     }));
     match result {
         Ok(Ok(())) => Ok(()),
@@ -102,7 +399,7 @@ fn run_tui(plan: DslPlan, debug: bool) -> PyResult<()> {
 ///
 /// Args:
 ///     data: Bytes from LazyFrame.serialize() or df.lazy().serialize() (binary).
-///     debug: If True, enable debug overlay (default False).
+///     options: Optional DatuiOptions (includes debug); default when None.
 ///
 /// Raises:
 ///     ValueError: If the bytes are not valid LazyFrame binary.
@@ -110,11 +407,11 @@ fn run_tui(plan: DslPlan, debug: bool) -> PyResult<()> {
 ///     PermissionError: If read access is denied (internal).
 ///     RuntimeError: If the TUI fails or panics.
 #[pyfunction]
-#[pyo3(signature = (data, *, debug=false))]
+#[pyo3(signature = (data, *, options=None))]
 fn view_from_bytes(
     _py: Python<'_>,
     data: &[u8],
-    debug: bool,
+    options: Option<Bound<'_, DatuiOptionsPy>>,
 ) -> PyResult<()> {
     let (plan, _): (DslPlan, usize) = bincode::serde::decode_from_slice(data, legacy())
         .map_err(|e| {
@@ -123,7 +420,8 @@ fn view_from_bytes(
                 e
             ))
         })?;
-    run_tui(plan, debug)
+    let opts = datui_options_to_rust(options.as_ref());
+    run_tui(plan, opts)
 }
 
 /// Launch the datui TUI with a LazyFrame logical plan given as JSON.
@@ -135,7 +433,7 @@ fn view_from_bytes(
 ///
 /// Args:
 ///     json_str: JSON string from LazyFrame.serialize(format="json").
-///     debug: If True, enable debug overlay (default False).
+///     options: Optional DatuiOptions (includes debug); default when None.
 ///
 /// Raises:
 ///     ValueError: If the string is not valid LazyFrame JSON.
@@ -143,11 +441,11 @@ fn view_from_bytes(
 ///     PermissionError: If read access is denied (internal).
 ///     RuntimeError: If the TUI fails or panics.
 #[pyfunction]
-#[pyo3(signature = (json_str, *, debug=false))]
+#[pyo3(signature = (json_str, *, options=None))]
 fn view_from_json(
     _py: Python<'_>,
     json_str: &str,
-    debug: bool,
+    options: Option<Bound<'_, DatuiOptionsPy>>,
 ) -> PyResult<()> {
     let value: Value = serde_json::from_str(json_str).map_err(|e| {
         PyValueError::new_err(format!(
@@ -162,7 +460,8 @@ fn view_from_json(
             e
         ))
     })?;
-    run_tui(plan, debug)
+    let opts = datui_options_to_rust(options.as_ref());
+    run_tui(plan, opts)
 }
 
 /// Launch the datui TUI with one or more paths (local files, S3, GCS, or HTTP/HTTPS URLs).
@@ -176,7 +475,7 @@ fn view_from_json(
 /// Args:
 ///     paths: A single path string or a list of path strings (e.g. `"file.csv"`,
 ///            `"s3://bucket/file.csv"`, `["a.csv", "b.csv"]`, or `"data/**/*.parquet"`).
-///     debug: If True, enable debug overlay (default False).
+///     options: Optional DatuiOptions (includes debug); default when None.
 ///
 /// Raises:
 ///     ValueError: If paths is empty.
@@ -184,19 +483,19 @@ fn view_from_json(
 ///     PermissionError: If read access to a path is denied.
 ///     RuntimeError: If the TUI fails or an uncategorized error occurs.
 #[pyfunction]
-#[pyo3(signature = (paths, *, debug=false))]
+#[pyo3(signature = (paths, *, options=None))]
 fn view_paths(
     _py: Python<'_>,
     paths: Vec<String>,
-    debug: bool,
+    options: Option<Bound<'_, DatuiOptionsPy>>,
 ) -> PyResult<()> {
     if paths.is_empty() {
         return Err(PyValueError::new_err("paths must not be empty"));
     }
     let path_bufs: Vec<PathBuf> = paths.into_iter().map(PathBuf::from).collect();
-    let opts = OpenOptions::default();
+    let opts = datui_options_to_rust(options.as_ref());
     let result = panic::catch_unwind(panic::AssertUnwindSafe(|| {
-        run(RunInput::Paths(path_bufs, opts), None, debug)
+        run(RunInput::Paths(path_bufs, opts), None)
     }));
     match result {
         Ok(Ok(())) => Ok(()),
@@ -340,10 +639,12 @@ mod tests {
 }
 
 /// Native extension module. The public `datui` package is provided by Python code
-/// (datui/__init__.py) which imports this as _datui and exposes view(), view_from_bytes(),
-/// view_from_json(), view_paths(), run_cli.
+/// (datui/__init__.py) which imports this as _datui and exposes view(), DatuiOptions,
+/// CompressionFormat, view_from_bytes(), view_from_json(), view_paths(), run_cli.
 #[pymodule]
 fn _datui(m: &Bound<'_, PyModule>) -> PyResult<()> {
+    m.add_class::<DatuiOptionsPy>()?;
+    m.add_class::<CompressionFormatPy>()?;
     m.add_function(wrap_pyfunction!(view_from_bytes, m)?)?;
     m.add_function(wrap_pyfunction!(view_from_json, m)?)?;
     m.add_function(wrap_pyfunction!(view_paths, m)?)?;

--- a/python/datui/__init__.py
+++ b/python/datui/__init__.py
@@ -12,6 +12,67 @@ import datui._datui  # noqa: F401  # pyright: ignore[reportMissingImports]
 
 PathLike = str | Path
 
+# Re-export options types so users can do datui.DatuiOptions(...), datui.CompressionFormat.Gzip
+DatuiOptions = datui._datui.DatuiOptions
+CompressionFormat = datui._datui.CompressionFormat
+
+# Keyword arguments accepted by view(..., **kwargs) and DatuiOptions; unknown kwargs raise TypeError.
+_DATUI_OPTIONS_KEYS = frozenset({
+    "delimiter",
+    "has_header",
+    "skip_lines",
+    "skip_rows",
+    "compression",
+    "pages_lookahead",
+    "pages_lookback",
+    "max_buffered_rows",
+    "max_buffered_mb",
+    "row_numbers",
+    "row_start_index",
+    "hive",
+    "single_spine_schema",
+    "parse_dates",
+    "decompress_in_memory",
+    "temp_dir",
+    "excel_sheet",
+    "s3_endpoint_url",
+    "s3_access_key_id",
+    "s3_secret_access_key",
+    "s3_region",
+    "polars_streaming",
+    "workaround_pivot_date_index",
+    "null_values",
+    "debug",
+})
+
+
+def _normalize_delimiter(value: int | str) -> int:
+    """Convert delimiter to int 0-255 for Rust. Accepts single-char str or int."""
+    if isinstance(value, str):
+        if len(value) != 1:
+            raise ValueError("delimiter as str must be a single character")
+        return ord(value)
+    return int(value)
+
+
+def _merge_options(options: DatuiOptions | None, kwargs: dict) -> DatuiOptions | None:
+    """Build options from options and/or kwargs. Kwargs override options. Returns None if both empty."""
+    if not kwargs and options is None:
+        return None
+    if options is not None and not kwargs:
+        return options
+    bad = set(kwargs) - _DATUI_OPTIONS_KEYS
+    if bad:
+        raise TypeError(f"invalid option(s) for view: {sorted(bad)}; valid: {sorted(_DATUI_OPTIONS_KEYS)}")
+    if options is not None:
+        base = dict(options._as_dict())
+        merged = {**base, **kwargs}
+    else:
+        merged = dict(kwargs)
+    if "delimiter" in merged:
+        merged["delimiter"] = _normalize_delimiter(merged["delimiter"])
+    return datui._datui.DatuiOptions(**merged)
+
 
 def _to_path_strings(data: str | Path | list[PathLike] | tuple[PathLike, ...]) -> list[str]:
     """Return a non-empty list of path strings. Raises ValueError if data is an empty sequence."""
@@ -23,12 +84,12 @@ def _to_path_strings(data: str | Path | list[PathLike] | tuple[PathLike, ...]) -
     return paths
 
 
-def _view_frame(lf: pl.LazyFrame, *, debug: bool) -> None:
+def _view_frame(lf: pl.LazyFrame, *, options: DatuiOptions | None) -> None:
     """Serialize LazyFrame plan and launch TUI. Tries binary first, falls back to JSON."""
     payload = lf.serialize()
     if isinstance(payload, bytes):
         try:
-            datui._datui.view_from_bytes(payload, debug=debug)
+            datui._datui.view_from_bytes(payload, options=options)
             return
         except (ValueError, RuntimeError):
             pass
@@ -42,7 +103,7 @@ def _view_frame(lf: pl.LazyFrame, *, debug: bool) -> None:
                     "this Polars version does not support format='json'."
                 ) from None
             if isinstance(json_payload, str):
-                datui._datui.view_from_json(json_payload, debug=debug)
+                datui._datui.view_from_json(json_payload, options=options)
                 return
         raise RuntimeError(
             "LazyFrame could not be sent to Datui; Polars version may be incompatible."
@@ -50,7 +111,7 @@ def _view_frame(lf: pl.LazyFrame, *, debug: bool) -> None:
     if isinstance(payload, str):
         with warnings.catch_warnings():
             warnings.filterwarnings("ignore", message=".*json.*deprecated", category=UserWarning)
-            datui._datui.view_from_json(payload, debug=debug)
+            datui._datui.view_from_json(payload, options=options)
         return
     raise RuntimeError("LazyFrame.serialize() returned an unsupported type")
 
@@ -58,7 +119,8 @@ def _view_frame(lf: pl.LazyFrame, *, debug: bool) -> None:
 def view(
     data: pl.LazyFrame | pl.DataFrame | PathLike | list[PathLike] | tuple[PathLike, ...],
     *,
-    debug: bool = False,
+    options: DatuiOptions | None = None,
+    **kwargs: object,
 ) -> None:
     """
     View data in the terminal.
@@ -67,13 +129,24 @@ def view(
     (s3://, gs://, http(s)://). Remote non-Parquet files are downloaded to a temp
     file. With multiple paths, at most one may be remote.
 
+    Options (path-based viewing): delimiter, has_header, skip_lines, skip_rows,
+    compression, null_values, hive, debug, etc. (see DatuiOptions). For frame-based
+    viewing only display/buffer options (e.g. row_numbers, pages_lookahead, debug) apply.
+    Pass options as a DatuiOptions instance or as keyword arguments.
+
+    Args:
+        data: Path(s), LazyFrame, or DataFrame.
+        options: Optional DatuiOptions; use default options when None.
+        **kwargs: Optional DatuiOptions fields (override options when both given).
+
     Raises:
-        TypeError: Unsupported type for data.
+        TypeError: Unsupported type for data or invalid option keyword.
         ValueError: Empty path list or invalid LazyFrame serialization.
         FileNotFoundError: A given path does not exist.
         PermissionError: Read access denied for a path.
         RuntimeError: Error serializing LazyFrame plan or launching the TUI (last resort).
     """
+    opts = _merge_options(options, kwargs)
     if isinstance(data, str) or isinstance(data, Path) or isinstance(data, (list, tuple)):
         if not hasattr(datui._datui, "view_paths"):
             _ext = getattr(datui._datui, "__file__", "unknown")
@@ -83,7 +156,7 @@ def view(
                 "If you switched Python/ABI: remove that file so the venv install is used, "
                 "or run: cd python && maturin develop"
             )
-        datui._datui.view_paths(_to_path_strings(data), debug=debug)
+        datui._datui.view_paths(_to_path_strings(data), options=opts)
         return
 
     if hasattr(data, "lazy") and callable(getattr(data, "lazy", None)):
@@ -97,6 +170,6 @@ def view(
         )
 
     try:
-        _view_frame(lf, debug=debug)
+        _view_frame(lf, options=opts)
     except AttributeError as e:
         raise TypeError("data must be a LazyFrame or DataFrame") from e

--- a/python/tests/test_datui.py
+++ b/python/tests/test_datui.py
@@ -10,6 +10,8 @@ def test_import_datui():
     import datui
 
     assert hasattr(datui, "view")
+    assert hasattr(datui, "DatuiOptions")
+    assert hasattr(datui, "CompressionFormat")
 
 
 def test_view_accepts_lazyframe():
@@ -83,7 +85,7 @@ def test_view_paths_empty_raises():
     import datui._datui
 
     with pytest.raises(ValueError, match="paths must not be empty"):
-        datui._datui.view_paths([], debug=False)
+        datui._datui.view_paths([])
 
 
 def test_run_cli_exists():
@@ -92,3 +94,52 @@ def test_run_cli_exists():
 
     assert hasattr(datui._datui, "run_cli")
     assert callable(datui._datui.run_cli)
+
+
+def test_datui_options_constructible():
+    """DatuiOptions should be constructible with kwargs (no TUI run)."""
+    import datui
+
+    opts = datui.DatuiOptions(delimiter=ord(","), skip_rows=2, row_numbers=True)
+    assert opts is not None
+    d = opts._as_dict()
+    assert d["delimiter"] == 44
+    assert d["skip_rows"] == 2
+    assert d["row_numbers"] is True
+    assert d["debug"] is False
+
+
+def test_datui_options_debug():
+    """DatuiOptions(debug=True) stores debug; view(..., debug=True) is valid via kwargs."""
+    import datui
+
+    opts = datui.DatuiOptions(debug=True)
+    assert opts._as_dict()["debug"] is True
+
+
+def test_datui_options_delimiter_single_char():
+    """DatuiOptions accepts single-char str for delimiter."""
+    import datui
+
+    opts = datui.DatuiOptions(delimiter=";")
+    assert opts is not None
+    d = opts._as_dict()
+    assert d["delimiter"] == ord(";")
+
+
+def test_view_invalid_kwarg_raises():
+    """view() with invalid option keyword should raise TypeError."""
+    import datui
+
+    with pytest.raises(TypeError, match="invalid option"):
+        datui.view("nonexistent.csv", not_an_option=1)
+
+
+def test_compression_format_values():
+    """CompressionFormat should expose gzip, zstd, bzip2, xz."""
+    import datui
+
+    assert hasattr(datui.CompressionFormat, "Gzip")
+    assert hasattr(datui.CompressionFormat, "Zstd")
+    assert hasattr(datui.CompressionFormat, "Bzip2")
+    assert hasattr(datui.CompressionFormat, "Xz")

--- a/src/main.rs
+++ b/src/main.rs
@@ -118,7 +118,7 @@ fn main() -> Result<()> {
     let opts = OpenOptions::from_args_and_config(&args, &config);
     let input = RunInput::Paths(args.paths.clone(), opts);
 
-    if let Err(e) = datui::run(input, Some(config), args.debug) {
+    if let Err(e) = datui::run(input, Some(config)) {
         eprintln!("Error: {}", e);
         std::process::exit(1);
     }


### PR DESCRIPTION
- Expose DatuiOptions to python module
- Add debug to OpenOptions (rust, DatuiOptions python)
- Remove debug as an arg to datui.view (replaced with options)

```
Python 3.14.2 (main, Jan 10 2026, 20:53:44) [GCC 15.2.1 20260103] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import datui
>>> datui.view("large_dataset.parquet")
# options can be passed as an object
>>> datui.view("large_dataset.parquet", options=datui.DatuiOptions(debug=True))
# options can be passed as kwargs
>>> datui.view("large_dataset.parquet", debug=True)
```