### PR TITLE
Harden CI: SHA-pin third-party actions and drop unused ci-gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,7 +63,8 @@ jobs:
       - uses: actions/checkout@v5
 
       - name: Free disk space (Ubuntu)
-        uses: jlumbroso/free-disk-space@main
+        # SHA-pinned to defend against upstream takeover; bump deliberately.
+        uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # main as of 2023-10-18
         with:
           tool-cache: false
           android: true
@@ -153,7 +154,6 @@ jobs:
   windows:
     runs-on: windows-latest
     needs: [check]
-    environment: ci-gate
     if: needs.check.outputs.is_dev_version != 'true'
     env:
       CARGO_TARGET_DIR: ${{ github.workspace }}/target
@@ -227,7 +227,6 @@ jobs:
   macos:
     runs-on: macos-latest
     needs: [check]
-    environment: ci-gate
     if: needs.check.outputs.is_dev_version != 'true'
     env:
       CARGO_TARGET_DIR: ${{ github.workspace }}/target

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -20,7 +20,8 @@ jobs:
       - uses: actions/checkout@v5
 
       - name: Free disk space (Ubuntu)
-        uses: jlumbroso/free-disk-space@main
+        # SHA-pinned to defend against upstream takeover; bump deliberately.
+        uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # main as of 2023-10-18
         with:
           tool-cache: false
           android: true

--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -179,7 +179,8 @@ jobs:
     # winget-releaser fetches release assets via GitHub API; no local download needed
     steps:
       - name: Open winget-pkgs PR
-        uses: vedantmgoyal9/winget-releaser@main
+        # SHA-pinned to defend against upstream takeover; bump deliberately.
+        uses: vedantmgoyal9/winget-releaser@7bd472be23763def6e16bd06cc8b1cdfab0e2fd5 # main as of 2026-03-15
         with:
           identifier: derekwisong.datui
           installers-regex: '-windows-x86_64\.zip$'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,7 +46,8 @@ jobs:
           fetch-tags: true
 
       - name: Free disk space (Ubuntu)
-        uses: jlumbroso/free-disk-space@main
+        # SHA-pinned to defend against upstream takeover; bump deliberately.
+        uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # main as of 2023-10-18
         with:
           tool-cache: false
           android: true


### PR DESCRIPTION
## Summary

- SHA-pin the two `@main` third-party actions so an upstream takeover can't immediately run new code in workflows that hold release secrets:
  - `jlumbroso/free-disk-space@54081f1` (in `ci.yml`, `nightly.yml`, `release.yml`)
  - `vedantmgoyal9/winget-releaser@7bd472b` (in `publish-packages.yml`; runs with `WINGET_TOKEN`)
- Each pin has a comment with the source ref + date so deliberate bumps stay reviewable.
- Drop the `environment: ci-gate` from the windows/macos jobs. The environment had no protection rules configured, so it gated nothing for fork PRs; the `if: is_dev_version != 'true'` skip (still in place) is the actual time-saving intent. Orphaned environment also deleted from repo settings.

## Test plan

- [x] CI green on this PR (linux runs; windows/macos skipped because version is `-dev`).
- [x] No reference to `ci-gate` remains: `grep -rn 'ci-gate' .github/workflows/` returns nothing.
- [x] `gh api repos/derekwisong/datui/environments` shows only `github-pages`.