### PR TITLE
Fix v0.2.53 release failures and clear Node 20 deprecation warnings

### DIFF
--- a/.github/workflows/build-and-publish-docs.yml
+++ b/.github/workflows/build-and-publish-docs.yml
@@ -113,7 +113,7 @@ jobs:
           find book-deploy -name .built_sha -delete
 
       - name: Upload Pages artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v5
         with:
           path: ./book-deploy
 
@@ -128,8 +128,8 @@ jobs:
       id-token: write
     steps:
       - name: Setup Pages
-        uses: actions/configure-pages@v4
+        uses: actions/configure-pages@v6
 
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -102,7 +102,7 @@ jobs:
           cd python && maturin build --release --out dist
 
       - name: Upload packaging artifacts
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v7
         with:
           name: nightly-linux
           path: |
@@ -162,7 +162,7 @@ jobs:
           maturin build --release --out dist
 
       - name: Upload Windows wheel and binary
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v7
         with:
           name: nightly-windows
           path: |
@@ -243,7 +243,7 @@ jobs:
           cd python && maturin build --release --out dist --target ${{ matrix.target }}
 
       - name: Upload macOS artifacts
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v7
         with:
           name: nightly-macos-${{ matrix.target }}
           path: |

--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -163,7 +163,10 @@ jobs:
           gh release download "${{ needs.resolve-release.outputs.tag_name }}" --repo ${{ github.repository }} --pattern 'PKGBUILD'
 
       - name: Publish to AUR (datui-bin package)
-        uses: KSXGitHub/github-actions-deploy-aur@v2.7.1
+        # SHA-pinned to defend against upstream takeover; bump deliberately.
+        # v2.7.1 broke after an Arch base image util-linux update tightened
+        # runuser's su-compatible option parsing (KSXGitHub#50).
+        uses: KSXGitHub/github-actions-deploy-aur@da03e160361ce01bf087e790b6ffd196d7dccff7 # v4.1.3
         with:
           pkgname: datui-bin
           pkgbuild: PKGBUILD
@@ -223,7 +226,8 @@ jobs:
           gpg --batch --yes -u "$GPG_EMAIL" --clearsign -o InRelease Release
 
       - name: Deploy to datui-apt
-        uses: peaceiris/actions-gh-pages@v3
+        # SHA-pinned to defend against upstream takeover; bump deliberately.
+        uses: peaceiris/actions-gh-pages@1ef5a1b1df4c63fe21a2242edbee6cac921ece01 # v4.1.0
         with:
           personal_token: ${{ secrets.DATUI_APT_TOKEN }}
           external_repository: derekwisong/datui-apt

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -204,15 +204,15 @@ jobs:
           find book-deploy -name .built_sha -delete
 
       - name: Setup Pages
-        uses: actions/configure-pages@v4
+        uses: actions/configure-pages@v6
 
       - name: Upload Pages artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v5
         with:
           path: ./book-deploy
 
       - name: Upload linux artifacts
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v7
         with:
           name: datui-linux-artifacts
           path: |
@@ -284,7 +284,7 @@ jobs:
           Compress-Archive -Path "$staging/*" -DestinationPath "datui-${version}-windows-x86_64.zip"
 
       - name: Upload Windows artifacts
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v7
         with:
           name: datui-windows-artifacts
           path: |
@@ -370,7 +370,7 @@ jobs:
           maturin build --release --out dist --target ${{ matrix.target }}
 
       - name: Upload macOS artifacts
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v7
         with:
           name: datui-macos-${{ matrix.target }}-artifacts
           path: |
@@ -393,30 +393,31 @@ jobs:
           fetch-depth: 0
 
       - name: Download linux artifacts
-        uses: actions/download-artifact@v5
+        uses: actions/download-artifact@v7
         with:
           name: datui-linux-artifacts
 
       - name: Download Windows artifacts
-        uses: actions/download-artifact@v5
+        uses: actions/download-artifact@v7
         with:
           name: datui-windows-artifacts
           path: windows-artifacts
 
       - name: Download macOS aarch64 artifacts
-        uses: actions/download-artifact@v5
+        uses: actions/download-artifact@v7
         with:
           name: datui-macos-aarch64-apple-darwin-artifacts
           path: macos-aarch64
 
       - name: Download macOS x86_64 artifacts
-        uses: actions/download-artifact@v5
+        uses: actions/download-artifact@v7
         with:
           name: datui-macos-x86_64-apple-darwin-artifacts
           path: macos-x86_64
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v2
+        # SHA-pinned to defend against upstream takeover; bump deliberately.
+        uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3.0.0
         with:
           tag_name: ${{ github.ref_name }}
           files: |
@@ -435,11 +436,11 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Setup Pages
-        uses: actions/configure-pages@v4
+        uses: actions/configure-pages@v6
 
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5
 
   publish-packages:
     needs: publish


### PR DESCRIPTION
## Summary

The v0.2.53 release surfaced two failures and a stack of Node 20 deprecation warnings:

- `publish-aur` failed with `bash: --command: invalid option`
- `publish-winget` failed with `derekwisong does not have the correct permissions to execute UpdateRef` (token issue, not in this PR)
- Every Node 20 action used in `release.yml` / `publish-packages.yml` / `nightly.yml` / `build-and-publish-docs.yml` triggered a deprecation warning; GitHub force-bumps Node 20 actions to Node 24 starting 2026-06-02 and removes the Node 20 runner image entirely on 2026-09-16.

## Fixes for actual failures

- **`KSXGitHub/github-actions-deploy-aur`: v2.7.1 → v4.1.3 (SHA-pinned)** — v2.7.1 broke after an Arch base image `util-linux` update tightened `runuser`'s su-compatible option parsing. The action's entrypoint runs `runuser builder --command 'bash -l -c /build.sh'` and the new `runuser` no longer consumes `--command` as its own flag, so it gets passed to bash. Documented in [KSXGitHub/github-actions-deploy-aur#50](https://github.com/KSXGitHub/github-actions-deploy-aur/issues/50) and fixed in [PR #49](https://github.com/KSXGitHub/github-actions-deploy-aur/pull/49) by switching to `runuser -u builder -- bash -l -c /build.sh`. Input schema is identical between v2.7.1 and v4.1.3 — drop-in bump.

The WinGet failure is a token-permission problem and is **not** addressed in this PR — `WINGET_TOKEN` needs to be regenerated as a classic PAT with `public_repo` scope (most likely cause: expired token).

## Node 20 → Node 24 runtime bumps

| Action | Before | After | Notes |
|---|---|---|---|
| `actions/upload-artifact` | `@v5` | `@v7` | v6 added Node 24, v7 adds ESM + optional direct-file uploads (opt-in, default unchanged) |
| `actions/download-artifact` | `@v5` | `@v7` | v6 added Node 24. Stopped at v7 deliberately — v8 changes default hash-mismatch behavior from warn to error, worth a separate decision |
| `actions/upload-pages-artifact` | `@v3` | `@v5` | Also clears the `upload-artifact@v4` warning that came from inside this action. v4 stops including dotfiles in the artifact — non-issue here, the `book-deploy` step already strips `.built_sha` |
| `actions/configure-pages` | `@v4` | `@v6` | Pure Node 24 bump |
| `actions/deploy-pages` | `@v4` | `@v5` | Pure Node 24 bump |
| `softprops/action-gh-release` | `@v2` | `@v3.0.0` (SHA-pinned) | v2.6.x is the Node 20 line; v3 is the Node 24 line |
| `peaceiris/actions-gh-pages` | `@v3` | `@v4.1.0` (SHA-pinned) | Node 16 → 24, no input changes |

Third-party actions are SHA-pinned with a trailing version comment to match the convention from 6174bf6 (Harden CI: SHA-pin third-party actions).

## Test plan

- [x] Confirm CI passes on this PR
- [x] On the next release, watch `publish-aur` — should no longer hit the `--command` bug
- [x] On the next release, watch the workflow run summary for any remaining Node 20 deprecation annotations
- [x] **Separately** (not this PR): regenerate `WINGET_TOKEN` as a classic PAT with `public_repo` scope before the next release