### PR TITLE
Fix nightly RPM build by sanitizing -dev version

### DIFF
--- a/scripts/packaging/build_package.py
+++ b/scripts/packaging/build_package.py
@@ -20,6 +20,7 @@ import glob
 import os
 import subprocess
 import sys
+import tomllib
 from pathlib import Path
 
 PKG_CHOICES = ("deb", "rpm", "aur")
@@ -65,6 +66,23 @@ def ensure_gzipped_manpage(repo_root: Path) -> bool:
             sys.stderr.write(proc.stderr)
         return False
     return (repo_root / "target" / "release" / "datui.1.gz").exists()
+
+
+def rpm_version_override(repo_root: Path) -> str | None:
+    """Return an RPM-safe version when Cargo.toml's version contains '-'.
+
+    RPM disallows '-' in versions (it separates version from release). Tilde is
+    RPM's pre-release marker, so '0.2.54~dev' correctly sorts below '0.2.54'
+    — unlike '.dev', which would sort above. cargo-generate-rpm 0.21 enforces
+    this strictly; earlier versions did not, which is why the nightly only
+    started failing once that release rolled out.
+    """
+    with (repo_root / "Cargo.toml").open("rb") as f:
+        data = tomllib.load(f)
+    version = data.get("package", {}).get("version", "")
+    if "-" not in version:
+        return None
+    return version.replace("-", "~")
 
 
 def fix_aur_pkgbuild(repo_root: Path) -> bool:
@@ -182,6 +200,9 @@ def main() -> int:
         cmd = ["cargo", "aur"]
     elif args.pkg == "rpm":
         cmd = ["cargo", subcmd]
+        override = rpm_version_override(repo_root)
+        if override is not None:
+            cmd.extend(["-s", f'version="{override}"'])
     else:
         cmd = ["cargo", subcmd, "-p", "datui"]
     proc = run(cmd, cwd=repo_root)


### PR DESCRIPTION
## Summary
- The nightly's "Build rpm package" step has failed every night since 2026-05-16 with `invalid version "0.2.54-dev"`. Root cause: `cargo-generate-rpm` 0.21 (released around that date) added strict version validation that rejects `-`, the RPM version/release separator. The workflow installs `cargo-generate-rpm` unpinned, so the next nightly cache miss picked it up.
- Convert `-dev` → `~dev` before invoking `cargo generate-rpm` via its `-s 'version="..."'` flag. Tilde is RPM's pre-release marker, so `0.2.54~dev` sorts *below* `0.2.54` (unlike `.dev`, which would sort above). Mirrors the existing AUR fix at `fix_aur_pkgbuild` for the same hyphen restriction on Arch.
- Stable releases (no hyphen in version) bypass the override — `rpm_version_override` returns `None` and the cmd is unchanged, so release builds are untouched.

## Test plan
- [x] Reproduced CI failure locally with `cargo-generate-rpm` 0.21.0 — same error message as the failing job.
- [x] Ran `python3 scripts/packaging/build_package.py rpm --no-build` with the fix — produces `target/generate-rpm/datui-0.2.54~dev-1.x86_64.rpm`.
- [x] Unit-checked `rpm_version_override` against stable / `-dev` / `-rc.1` versions — returns `None` / `0.2.54~dev` / `0.2.54~rc.1` respectively.
- [ ] Wait for the next nightly (or trigger manually) to confirm the linux job goes green.

Refs: failing run https://github.com/derekwisong/datui/actions/runs/26381255023