### PR TITLE
Open large hive datasets without waiting on a full row count

### DIFF
--- a/crates/datui-lib/src/lib.rs
+++ b/crates/datui-lib/src/lib.rs
@@ -608,14 +608,18 @@ pub enum AppEvent {
     BackgroundCollectReady {
         generation: u64,
     },
-    /// Background task completed: row count for the current LazyFrame. The handler
-    /// applies it to `data_table_state` and triggers the actual buffer collect.
-    /// `status` carries the original `spawn_async_collect` status string so the second
-    /// spawn keeps the user-facing message stable across the two-phase load.
+    /// Background task completed: exact row count for the current LazyFrame. Applied to
+    /// `data_table_state` only if `len_generation` still matches (the data is unchanged).
+    /// Runs concurrently with — and independently of — the first buffer paint, so the
+    /// count fills in the scrollbar/total without ever blocking the initial render.
     BackgroundLenReady {
-        generation: u64,
+        len_generation: u64,
         num_rows: usize,
-        status: String,
+    },
+    /// Background row count failed. Clears the in-flight marker so the count can be retried
+    /// on a later interaction; the total stays provisional in the meantime.
+    BackgroundLenFailed {
+        len_generation: u64,
     },
     /// Background task completed: schema loaded and DataTableState constructed.
     /// The actual state is stored in App::pending_schema_result (to avoid cloning DataTableState).
@@ -1007,6 +1011,9 @@ pub struct App {
     column_colors: bool, // When true, colorize table cells by column type (from config.display.column_colors)
     runtime: tokio::runtime::Handle, // Tokio runtime handle for background tasks
     task_generation: u64, // Incremented to invalidate stale background results
+    // `len_generation` of the in-flight background row-count, if any. Prevents re-spawning
+    // the (potentially minutes-long) count on every scroll while it's still running.
+    len_count_inflight: Option<u64>,
     pending_schema_result: std::sync::Arc<std::sync::Mutex<Option<(u64, DataTableState)>>>, // (generation, result) from background schema load
     pending_collect_result:
         std::sync::Arc<std::sync::Mutex<Option<(u64, crate::widgets::datatable::CollectResult)>>>, // (generation, result) from background buffer load
@@ -1124,46 +1131,59 @@ impl App {
     /// Spawn an async buffer collect if needed. Returns true if a background task was spawned.
     /// Increments task_generation to invalidate any in-flight collect from a prior call.
     ///
-    /// When the LazyFrame's row count is unknown (e.g. just after a filter/sort/pivot/melt
-    /// that invalidates the cache), this first spawns a `len()` task off-thread; the
-    /// `BackgroundLenReady` handler then re-enters here to spawn the actual buffer collect.
+    /// When the LazyFrame's row count is unknown (e.g. fresh load, or just after a
+    /// filter/sort/pivot/melt that invalidates the cache), the exact `len()` is computed
+    /// in the background and applied later via `BackgroundLenReady` — it never gates the
+    /// buffer paint. `prepare_async_collect` plans a top-of-data window when the count is
+    /// still unknown, so the first screen renders immediately. For large/partitioned/remote
+    /// datasets the count can take a long time; it runs silently and concurrently.
     pub fn spawn_async_collect(&mut self, status: &str) -> bool {
         let Some(state) = self.data_table_state.as_mut() else {
             return false;
         };
 
+        // Kick off the exact row count off-thread when it isn't known, unless one is
+        // already running for this data version. This task is independent of
+        // `task_generation` (a scroll must not restart it) and does not set `busy`.
         if !state.is_num_rows_valid() {
-            self.task_generation = self.task_generation.wrapping_add(1);
-            let lf = state.lf_clone();
-            let streaming = state.polars_streaming_enabled();
-            let status_owned = status.to_string();
-            self.spawn_bg(status, move |gen, tx| {
-                let num_rows = match crate::statistics::collect_lazy(lf.select([len()]), streaming)
-                {
-                    Ok(df) => match df.get(0) {
-                        Some(col) => match col.first() {
-                            Some(AnyValue::UInt32(n)) => *n as usize,
-                            _ => 0,
-                        },
-                        None => 0,
-                    },
-                    Err(e) => {
-                        let _ = tx.send(AppEvent::BackgroundError {
-                            generation: gen,
-                            message: crate::error_display::user_message_from_polars(&e),
-                        });
-                        return;
+            let len_gen = state.len_generation();
+            if self.len_count_inflight != Some(len_gen) {
+                let lf = state.lf_clone();
+                let streaming = state.polars_streaming_enabled();
+                self.len_count_inflight = Some(len_gen);
+                let tx = self.events.clone();
+                self.runtime.spawn_blocking(move || {
+                    match crate::statistics::collect_lazy(lf.select([len()]), streaming) {
+                        Ok(df) => {
+                            let num_rows = match df.get(0) {
+                                Some(col) => match col.first() {
+                                    Some(AnyValue::UInt32(n)) => *n as usize,
+                                    _ => 0,
+                                },
+                                None => 0,
+                            };
+                            let _ = tx.send(AppEvent::BackgroundLenReady {
+                                len_generation: len_gen,
+                                num_rows,
+                            });
+                        }
+                        // Count failed: leave the total provisional and allow a retry on a
+                        // later interaction. The buffer paint below is unaffected.
+                        Err(_) => {
+                            let _ = tx.send(AppEvent::BackgroundLenFailed {
+                                len_generation: len_gen,
+                            });
+                        }
                     }
-                };
-                let _ = tx.send(AppEvent::BackgroundLenReady {
-                    generation: gen,
-                    num_rows,
-                    status: status_owned,
                 });
-            });
-            return true;
+            }
         }
 
+        // Plan and spawn the buffer collect. With the count unknown this is a top-of-data
+        // window (`slice(0, N)`) that touches only the first file(s) of a partitioned set.
+        let Some(state) = self.data_table_state.as_mut() else {
+            return false;
+        };
         let Some(request) = state.prepare_async_collect(None) else {
             return false;
         };
@@ -1183,6 +1203,7 @@ impl App {
                                 buffer_start: request.buffer_start,
                                 buffer_end: request.buffer_end,
                                 num_rows: request.num_rows,
+                                count_known: request.count_known,
                             },
                         ));
                     }
@@ -1399,6 +1420,7 @@ impl App {
             runtime,
             task_generation: 0,
             pending_schema_result: std::sync::Arc::new(std::sync::Mutex::new(None)),
+            len_count_inflight: None,
             pending_collect_result: std::sync::Arc::new(std::sync::Mutex::new(None)),
             busy: false,
             throbber_frame: 0,
@@ -7352,22 +7374,26 @@ impl App {
                 None
             }
             AppEvent::BackgroundLenReady {
-                generation,
+                len_generation,
                 num_rows,
-                status,
             } => {
-                if *generation == self.task_generation {
-                    if let Some(state) = self.data_table_state.as_mut() {
+                if self.len_count_inflight == Some(*len_generation) {
+                    self.len_count_inflight = None;
+                }
+                // Apply the exact total only if the data hasn't changed since the count
+                // was spawned. This runs independently of the buffer paint (which has
+                // usually already rendered), so it just corrects the scrollbar/total —
+                // no busy state, no re-collect.
+                if let Some(state) = self.data_table_state.as_mut() {
+                    if state.len_generation() == *len_generation {
                         state.set_num_rows(*num_rows);
                     }
-                    // Re-enter spawn_async_collect; now num_rows is valid so it'll spawn
-                    // the actual buffer collect with the correct bounds.
-                    if !self.spawn_async_collect(status) {
-                        self.loading_state = LoadingState::Idle;
-                        self.status_message = None;
-                        self.busy = false;
-                        self.drain_keys_on_next_loop = true;
-                    }
+                }
+                None
+            }
+            AppEvent::BackgroundLenFailed { len_generation } => {
+                if self.len_count_inflight == Some(*len_generation) {
+                    self.len_count_inflight = None;
                 }
                 None
             }
@@ -8811,6 +8837,28 @@ pub fn run(input: RunInput, config: Option<AppConfig>) -> Result<()> {
         .build()
         .map_err(|e| color_eyre::eyre::eyre!("Failed to create tokio runtime: {}", e))?;
 
+    // Background work (e.g. the row-count `len()` over a huge or remote dataset) runs on
+    // the runtime's blocking pool. Dropping the runtime normally *joins* those threads, so
+    // quitting would hang until an in-flight count finished — minutes for a 474 GB hive
+    // set. Shut the runtime down in the background instead: exit is immediate and the
+    // abandoned read-only task dies with the process. This guard covers every return path
+    // (Exit, Crash, `?`-propagated errors, channel disconnect).
+    struct RtGuard(Option<tokio::runtime::Runtime>);
+    impl Drop for RtGuard {
+        fn drop(&mut self) {
+            if let Some(rt) = self.0.take() {
+                rt.shutdown_background();
+            }
+        }
+    }
+    let rt_guard = RtGuard(Some(rt));
+    let rt_handle = rt_guard
+        .0
+        .as_ref()
+        .expect("runtime present")
+        .handle()
+        .clone();
+
     let mut terminal = ratatui::try_init().map_err(|e| {
         color_eyre::eyre::eyre!(
             "datui requires an interactive terminal (TTY). No terminal detected: {}. \
@@ -8819,7 +8867,7 @@ pub fn run(input: RunInput, config: Option<AppConfig>) -> Result<()> {
         )
     })?;
     let (tx, rx) = mpsc::channel::<AppEvent>();
-    let mut app = App::new_with_config(tx.clone(), rt.handle().clone(), theme, config.clone());
+    let mut app = App::new_with_config(tx.clone(), rt_handle, theme, config.clone());
     if opts.debug {
         app.enable_debug();
     }

--- a/crates/datui-lib/src/lib.rs
+++ b/crates/datui-lib/src/lib.rs
@@ -1107,6 +1107,14 @@ impl App {
             self.original_file_format = None;
             self.original_file_delimiter = None;
         }
+        // Enable the cheap footer-sum row count for a local Parquet hive directory.
+        if options.hive {
+            if let Some(p) = path.as_ref().filter(|p| p.is_dir()) {
+                if let Some(state) = self.data_table_state.as_mut() {
+                    state.set_parquet_count_dir(p.clone());
+                }
+            }
+        }
         self.sort_filter_modal = SortFilterModal::new();
         self.pivot_melt_modal = PivotMeltModal::new();
         if let LoadingState::Loading {
@@ -1148,20 +1156,36 @@ impl App {
         if !state.is_num_rows_valid() {
             let len_gen = state.len_generation();
             if self.len_count_inflight != Some(len_gen) {
+                // Prefer the cheap footer-sum count for a pristine local Parquet hive
+                // directory; otherwise fall back to a `len()` data scan.
+                let count_dir = state.parquet_count_dir();
                 let lf = state.lf_clone();
                 let streaming = state.polars_streaming_enabled();
                 self.len_count_inflight = Some(len_gen);
                 let tx = self.events.clone();
                 self.runtime.spawn_blocking(move || {
-                    match crate::statistics::collect_lazy(lf.select([len()]), streaming) {
-                        Ok(df) => {
-                            let num_rows = match df.get(0) {
-                                Some(col) => match col.first() {
-                                    Some(AnyValue::UInt32(n)) => *n as usize,
-                                    _ => 0,
-                                },
-                                None => 0,
-                            };
+                    let counted = match count_dir {
+                        Some(dir) => {
+                            crate::widgets::datatable::DataTableState::count_rows_from_parquet_dir(
+                                &dir,
+                            )
+                            .map_err(|_| ())
+                        }
+                        None => {
+                            match crate::statistics::collect_lazy(lf.select([len()]), streaming) {
+                                Ok(df) => Ok(match df.get(0) {
+                                    Some(col) => match col.first() {
+                                        Some(AnyValue::UInt32(n)) => *n as usize,
+                                        _ => 0,
+                                    },
+                                    None => 0,
+                                }),
+                                Err(_) => Err(()),
+                            }
+                        }
+                    };
+                    match counted {
+                        Ok(num_rows) => {
                             let _ = tx.send(AppEvent::BackgroundLenReady {
                                 len_generation: len_gen,
                                 num_rows,
@@ -1169,7 +1193,7 @@ impl App {
                         }
                         // Count failed: leave the total provisional and allow a retry on a
                         // later interaction. The buffer paint below is unaffected.
-                        Err(_) => {
+                        Err(()) => {
                             let _ = tx.send(AppEvent::BackgroundLenFailed {
                                 len_generation: len_gen,
                             });
@@ -1595,6 +1619,13 @@ impl App {
                     self.path = Some(path.clone());
                     self.original_file_format = Some(ExportFormat::Parquet);
                     self.original_file_delimiter = None;
+                    // Enable the cheap footer-sum row count for a local hive directory
+                    // (globs go through the same constructor but aren't a single dir).
+                    if path.is_dir() {
+                        if let Some(state) = self.data_table_state.as_mut() {
+                            state.set_parquet_count_dir(path.clone());
+                        }
+                    }
                     self.sort_filter_modal = SortFilterModal::new();
                     self.pivot_melt_modal = PivotMeltModal::new();
                     return Ok(());

--- a/crates/datui-lib/src/widgets/datatable.rs
+++ b/crates/datui-lib/src/widgets/datatable.rs
@@ -2,7 +2,7 @@ use color_eyre::Result;
 use std::borrow::Cow;
 use std::collections::HashSet;
 use std::sync::Arc;
-use std::{fs, fs::File, path::Path};
+use std::{fs, fs::File, path::Path, path::PathBuf};
 
 use polars::io::HiveOptions;
 use polars::prelude::*;
@@ -75,6 +75,11 @@ pub struct DataTableState {
     /// longer matches is stale (the data changed) and is dropped. Decoupled from
     /// `task_generation` so a mere scroll doesn't invalidate / restart an in-flight count.
     len_generation: u64,
+    /// When set, the current `lf` is a pristine scan of this local Parquet hive directory,
+    /// so the exact row count equals the sum of per-file footer counts — far cheaper than
+    /// a `len()` data scan over a huge/partitioned set. Cleared whenever `lf` is mutated
+    /// (filter/query/group/etc.), since footers can't count row-reducing operations.
+    parquet_count_dir: Option<PathBuf>,
     filters: Vec<FilterStatement>,
     sort_columns: Vec<String>,
     sort_ascending: bool,
@@ -186,6 +191,7 @@ impl DataTableState {
             num_rows: 0,
             num_rows_valid: false,
             len_generation: 0,
+            parquet_count_dir: None,
             filters: Vec::new(),
             sort_columns: Vec::new(),
             sort_ascending: true,
@@ -271,6 +277,7 @@ impl DataTableState {
             num_rows: 0,
             num_rows_valid: false,
             len_generation: 0,
+            parquet_count_dir: None,
             filters: Vec::new(),
             sort_columns: Vec::new(),
             sort_ascending: true,
@@ -1175,6 +1182,87 @@ impl DataTableState {
             }
         }
         first_partition_child.and_then(|p| Self::first_parquet_file_spine(&p, depth + 1, max_depth))
+    }
+
+    /// Recursively collect every `*.parquet` file under `dir`. Unlike the single-spine
+    /// walks used for schema/partition discovery, this visits the whole tree because an
+    /// exact row count needs every file. Bounded depth guards against pathological trees.
+    fn collect_parquet_files(dir: &Path, out: &mut Vec<PathBuf>, depth: usize, max_depth: usize) {
+        if depth >= max_depth {
+            return;
+        }
+        let Ok(entries) = fs::read_dir(dir) else {
+            return;
+        };
+        for entry in entries.flatten() {
+            let child = entry.path();
+            if child.is_dir() {
+                Self::collect_parquet_files(&child, out, depth + 1, max_depth);
+            } else if child
+                .extension()
+                .is_some_and(|e| e.eq_ignore_ascii_case("parquet"))
+            {
+                out.push(child);
+            }
+        }
+    }
+
+    /// Exact row count for a local Parquet hive directory, computed by summing per-file
+    /// footer row counts (metadata only — no data is read). This is the cheap alternative
+    /// to a `len()` data scan: footers are tiny, so the cost is one metadata read per file,
+    /// fanned out across threads. Files that fail to read (e.g. an in-progress write) are
+    /// skipped so a single bad file can't force the slow path; `Err` only if the directory
+    /// has no readable Parquet files at all.
+    pub fn count_rows_from_parquet_dir(dir: &Path) -> Result<usize> {
+        const MAX_DEPTH: usize = 64;
+        let mut files = Vec::new();
+        Self::collect_parquet_files(dir, &mut files, 0, MAX_DEPTH);
+        if files.is_empty() {
+            return Err(color_eyre::eyre::eyre!(
+                "No parquet files found under {}",
+                dir.display()
+            ));
+        }
+
+        let workers = std::thread::available_parallelism()
+            .map(|n| n.get())
+            .unwrap_or(4)
+            .min(files.len())
+            .max(1);
+        let chunk_size = files.len().div_ceil(workers);
+
+        let (total, read_ok) = std::thread::scope(|scope| {
+            let handles: Vec<_> = files
+                .chunks(chunk_size)
+                .map(|chunk| {
+                    scope.spawn(move || {
+                        let mut sum = 0usize;
+                        let mut ok = 0usize;
+                        for path in chunk {
+                            if let Ok(file) = File::open(path) {
+                                if let Ok(n) = ParquetReader::new(file).num_rows() {
+                                    sum += n;
+                                    ok += 1;
+                                }
+                            }
+                        }
+                        (sum, ok)
+                    })
+                })
+                .collect();
+            handles.into_iter().fold((0usize, 0usize), |(s, o), h| {
+                let (cs, co) = h.join().unwrap_or((0, 0));
+                (s + cs, o + co)
+            })
+        });
+
+        if read_ok == 0 {
+            return Err(color_eyre::eyre::eyre!(
+                "Could not read any parquet footers under {}",
+                dir.display()
+            ));
+        }
+        Ok(total)
     }
 
     /// Read schema from a single parquet file (metadata only, no data scan). Used to avoid collect_schema() over many files.
@@ -2970,10 +3058,26 @@ impl DataTableState {
     }
 
     /// Invalidate num_rows cache when lf is mutated. Bumps `len_generation` so any
-    /// in-flight background count for the previous `lf` is recognized as stale.
+    /// in-flight background count for the previous `lf` is recognized as stale. Also drops
+    /// the cheap Parquet-footer count source: once `lf` carries a filter/query/group, the
+    /// row count no longer equals the sum of file footers.
     fn invalidate_num_rows(&mut self) {
         self.num_rows_valid = false;
         self.len_generation = self.len_generation.wrapping_add(1);
+        self.parquet_count_dir = None;
+    }
+
+    /// Record that the current `lf` is a pristine scan of `dir` (a local Parquet hive
+    /// directory), enabling the cheap footer-sum row count. Set by the loader; cleared by
+    /// `invalidate_num_rows` on any row-changing mutation.
+    pub fn set_parquet_count_dir(&mut self, dir: PathBuf) {
+        self.parquet_count_dir = Some(dir);
+    }
+
+    /// The directory whose Parquet footers can be summed for an exact row count, if the
+    /// current `lf` still allows it. See `parquet_count_dir`.
+    pub fn parquet_count_dir(&self) -> Option<PathBuf> {
+        self.parquet_count_dir.clone()
     }
 
     /// Current count generation. A background `len()` task captures this; its result is
@@ -5752,5 +5856,50 @@ mod tests {
                 curr
             );
         }
+    }
+
+    fn write_parquet(path: &Path, n: i64) {
+        let mut df = df!("v" => (0..n).collect::<Vec<i64>>()).unwrap();
+        let file = File::create(path).unwrap();
+        ParquetWriter::new(file).finish(&mut df).unwrap();
+    }
+
+    #[test]
+    fn test_count_rows_from_parquet_dir_sums_footers() {
+        let dir = tempfile::tempdir().unwrap();
+        // Hive-style layout: two partitions, multiple files each.
+        let p1 = dir.path().join("year=2020");
+        let p2 = dir.path().join("year=2021");
+        fs::create_dir_all(&p1).unwrap();
+        fs::create_dir_all(&p2).unwrap();
+        write_parquet(&p1.join("a.parquet"), 10);
+        write_parquet(&p1.join("b.parquet"), 5);
+        write_parquet(&p2.join("c.parquet"), 7);
+
+        let n = DataTableState::count_rows_from_parquet_dir(dir.path()).unwrap();
+        assert_eq!(n, 22, "should sum footer row counts across all files");
+    }
+
+    #[test]
+    fn test_count_rows_skips_non_parquet_and_corrupt_files() {
+        let dir = tempfile::tempdir().unwrap();
+        write_parquet(&dir.path().join("good.parquet"), 8);
+        // A non-parquet file must be ignored entirely.
+        fs::write(dir.path().join("notes.txt"), b"ignore me").unwrap();
+        // A corrupt .parquet must be skipped, not abort the whole count.
+        fs::write(dir.path().join("bad.parquet"), b"not a parquet footer").unwrap();
+
+        let n = DataTableState::count_rows_from_parquet_dir(dir.path()).unwrap();
+        assert_eq!(n, 8, "non-parquet and unreadable files should be skipped");
+    }
+
+    #[test]
+    fn test_count_rows_errors_when_no_readable_parquet() {
+        let dir = tempfile::tempdir().unwrap();
+        fs::write(dir.path().join("only.txt"), b"nothing here").unwrap();
+        assert!(
+            DataTableState::count_rows_from_parquet_dir(dir.path()).is_err(),
+            "a directory with no parquet files should error so the caller can fall back"
+        );
     }
 }

--- a/crates/datui-lib/src/widgets/datatable.rs
+++ b/crates/datui-lib/src/widgets/datatable.rs
@@ -70,6 +70,11 @@ pub struct DataTableState {
     pub num_rows: usize,
     /// When true, collect() skips the len() query.
     num_rows_valid: bool,
+    /// Bumped whenever `lf` changes (via `invalidate_num_rows`). A background `len()`
+    /// count carries the generation it was spawned under; a result whose generation no
+    /// longer matches is stale (the data changed) and is dropped. Decoupled from
+    /// `task_generation` so a mere scroll doesn't invalidate / restart an in-flight count.
+    len_generation: u64,
     filters: Vec<FilterStatement>,
     sort_columns: Vec<String>,
     sort_ascending: bool,
@@ -137,8 +142,11 @@ pub struct CollectRequest {
     pub buffer_start: usize,
     /// Buffer end row in the full dataset.
     pub buffer_end: usize,
-    /// Row count for the full (unsliced) dataset.
+    /// Row count for the full (unsliced) dataset. Only meaningful when `count_known`.
     pub num_rows: usize,
+    /// Whether `num_rows` is the true total. False for a first buffer rendered before
+    /// the background `len()` count has resolved; in that case `num_rows` is provisional.
+    pub count_known: bool,
 }
 
 /// Result of a background buffer load. Consumed by `apply_async_collect()`.
@@ -147,6 +155,8 @@ pub struct CollectResult {
     pub buffer_start: usize,
     pub buffer_end: usize,
     pub num_rows: usize,
+    /// See `CollectRequest::count_known`.
+    pub count_known: bool,
 }
 
 impl DataTableState {
@@ -175,6 +185,7 @@ impl DataTableState {
             schema,
             num_rows: 0,
             num_rows_valid: false,
+            len_generation: 0,
             filters: Vec::new(),
             sort_columns: Vec::new(),
             sort_ascending: true,
@@ -259,6 +270,7 @@ impl DataTableState {
             schema,
             num_rows: 0,
             num_rows_valid: false,
+            len_generation: 0,
             filters: Vec::new(),
             sort_columns: Vec::new(),
             sort_ascending: true,
@@ -2761,28 +2773,34 @@ impl DataTableState {
             self.num_rows = n;
             self.num_rows_valid = true;
         }
-        debug_assert!(
-            self.num_rows_valid,
-            "prepare_async_collect requires num_rows_valid; caller must run a background len() first",
-        );
 
-        if self.num_rows > 0 {
-            let max_start = self.num_rows.saturating_sub(1);
-            if self.start_row > max_start {
-                self.start_row = max_start;
+        // `bound` is the exact total when known, or `usize::MAX` while the background
+        // `len()` is still running. Using it instead of `self.num_rows` lets us plan a
+        // top-of-data window for first paint without waiting for the count. See
+        // `num_rows_bound`.
+        let count_known = self.num_rows_valid;
+        let bound = self.num_rows_bound();
+
+        if count_known {
+            if self.num_rows > 0 {
+                let max_start = self.num_rows.saturating_sub(1);
+                if self.start_row > max_start {
+                    self.start_row = max_start;
+                }
+            } else {
+                // Confirmed-empty dataset: clear everything.
+                self.start_row = 0;
+                self.buffered_start_row = 0;
+                self.buffered_end_row = 0;
+                self.buffered_df = None;
+                self.df = None;
+                self.locked_df = None;
+                return None;
             }
-        } else {
-            self.start_row = 0;
-            self.buffered_start_row = 0;
-            self.buffered_end_row = 0;
-            self.buffered_df = None;
-            self.df = None;
-            self.locked_df = None;
-            return None;
         }
 
         let view_start = self.start_row;
-        let view_end = self.start_row + self.visible_rows.min(self.num_rows - self.start_row);
+        let view_end = self.start_row + self.visible_rows.min(bound - self.start_row);
         let within_buffer = view_start >= self.buffered_start_row
             && view_end <= self.buffered_end_row
             && self.buffered_end_row > 0;
@@ -2795,7 +2813,7 @@ impl DataTableState {
             let needs_expansion_back =
                 dist_to_start <= self.proximity_threshold && self.buffered_start_row > 0;
             let needs_expansion_forward =
-                dist_to_end <= self.proximity_threshold && self.buffered_end_row < self.num_rows;
+                dist_to_end <= self.proximity_threshold && self.buffered_end_row < bound;
 
             if !needs_expansion_back && !needs_expansion_forward {
                 // Buffer is fine, just re-slice display.
@@ -2821,7 +2839,7 @@ impl DataTableState {
                     self.buffered_start_row
                 };
                 let mut e = if needs_expansion_forward {
-                    (view_end + self.pages_lookahead * page_rows).min(self.num_rows)
+                    (view_end + self.pages_lookahead * page_rows).min(bound)
                 } else {
                     self.buffered_end_row
                 };
@@ -2841,25 +2859,25 @@ impl DataTableState {
             let mut e;
             if extend_forward_ok {
                 s = self.buffered_start_row;
-                e = (view_end + self.pages_lookahead * page_rows).min(self.num_rows);
+                e = (view_end + self.pages_lookahead * page_rows).min(bound);
             } else if extend_backward_ok {
                 s = view_start.saturating_sub(self.pages_lookback * page_rows);
                 e = self.buffered_end_row;
             } else {
                 s = view_start.saturating_sub(self.pages_lookback * page_rows);
-                e = (view_end + self.pages_lookahead * page_rows).min(self.num_rows);
+                e = (view_end + self.pages_lookahead * page_rows).min(bound);
                 let min_initial_len = (1 + self.pages_lookahead + self.pages_lookback) * page_rows;
                 let current_len = e.saturating_sub(s);
                 if current_len < min_initial_len {
                     let need = min_initial_len.saturating_sub(current_len);
-                    let can_extend_end = self.num_rows.saturating_sub(e);
+                    let can_extend_end = bound.saturating_sub(e);
                     let can_extend_start = s;
                     if can_extend_end >= need {
-                        e = (e + need).min(self.num_rows);
+                        e = (e + need).min(bound);
                     } else if can_extend_start >= need {
                         s = s.saturating_sub(need);
                     } else {
-                        e = (e + can_extend_end).min(self.num_rows);
+                        e = (e + can_extend_end).min(bound);
                         s = s.saturating_sub(need.saturating_sub(can_extend_end));
                     }
                 }
@@ -2889,15 +2907,40 @@ impl DataTableState {
             polars_streaming: self.polars_streaming,
             buffer_start: new_buffer_start,
             buffer_end: new_buffer_end,
-            num_rows: self.num_rows,
+            // When the count isn't known yet, `num_rows` is provisional (the planned end of
+            // this buffer). `apply_async_collect` keeps `num_rows_valid` false so the
+            // background `len()` corrects it, unless the short read reveals the true end.
+            num_rows: if count_known {
+                self.num_rows
+            } else {
+                new_buffer_end
+            },
+            count_known,
         })
     }
 
     /// Apply the result of a background buffer load.
     pub fn apply_async_collect(&mut self, result: CollectResult) {
         let mut full_df = result.df;
-        self.num_rows = result.num_rows;
-        self.num_rows_valid = true;
+        let returned_rows = full_df.height();
+        let requested_rows = result.buffer_end.saturating_sub(result.buffer_start);
+
+        if result.count_known {
+            self.num_rows = result.num_rows;
+            self.num_rows_valid = true;
+        } else if returned_rows < requested_rows {
+            // Short read: the slice ran off the end, so we now know the exact total
+            // without waiting for the background len() count.
+            self.num_rows = result.buffer_start + returned_rows;
+            self.num_rows_valid = true;
+        } else if !self.num_rows_valid {
+            // Full buffer with the count still unresolved: render with a provisional
+            // total (at least this buffer's end) and leave num_rows_valid false so the
+            // in-flight background len() corrects it via set_num_rows().
+            self.num_rows = self.num_rows.max(result.buffer_end);
+        }
+        // else: the background len() already resolved the exact count between this
+        // buffer being requested and applied — keep it; don't downgrade to provisional.
         self.error = None;
 
         let mut effective_buffer_end = result.buffer_end;
@@ -2926,9 +2969,17 @@ impl DataTableState {
         }
     }
 
-    /// Invalidate num_rows cache when lf is mutated.
+    /// Invalidate num_rows cache when lf is mutated. Bumps `len_generation` so any
+    /// in-flight background count for the previous `lf` is recognized as stale.
     fn invalidate_num_rows(&mut self) {
         self.num_rows_valid = false;
+        self.len_generation = self.len_generation.wrapping_add(1);
+    }
+
+    /// Current count generation. A background `len()` task captures this; its result is
+    /// only applied if the generation still matches (i.e. the data hasn't changed since).
+    pub fn len_generation(&self) -> u64 {
+        self.len_generation
     }
 
     /// Returns the cached row count when valid (same value shown in the control bar). Use this to
@@ -2945,6 +2996,18 @@ impl DataTableState {
     /// to dispatch a background len() query before planning the buffer collect.
     pub fn is_num_rows_valid(&self) -> bool {
         self.num_rows_valid
+    }
+
+    /// Effective upper bound on row indices for buffer planning. When the exact count
+    /// is known, that's `num_rows`; when it isn't yet (first paint before the background
+    /// `len()` resolves), treat the dataset as unbounded so we plan a top-of-data window
+    /// (`slice(0, N)`) instead of clamping everything to a stale/zero count.
+    fn num_rows_bound(&self) -> usize {
+        if self.num_rows_valid {
+            self.num_rows
+        } else {
+            usize::MAX
+        }
     }
 
     /// Apply a row count computed in the background (so prepare_async_collect doesn't
@@ -2990,18 +3053,19 @@ impl DataTableState {
         if requested_len <= max_len {
             return;
         }
+        let bound = self.num_rows_bound();
         let view_len = view_end.saturating_sub(view_start);
         if view_len >= max_len {
             *buffer_start = view_start;
-            *buffer_end = (view_start + max_len).min(self.num_rows);
+            *buffer_end = (view_start + max_len).min(bound);
         } else {
             let half = (max_len - view_len) / 2;
-            *buffer_end = (view_end + half).min(self.num_rows);
+            *buffer_end = (view_end + half).min(bound);
             *buffer_start = (*buffer_end).saturating_sub(max_len);
             if *buffer_start > view_start {
                 *buffer_start = view_start;
             }
-            *buffer_end = (*buffer_start + max_len).min(self.num_rows);
+            *buffer_end = (*buffer_start + max_len).min(bound);
         }
     }
 

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -761,3 +761,71 @@ fn test_async_collect_handles_invalidated_num_rows() {
         "display buffer should be populated after async len + collect"
     );
 }
+
+/// Opening a Parquet hive directory should paint the first buffer and resolve the exact
+/// total row count via the footer-sum path (Fix 1 + Fix 2), without a full data scan.
+#[test]
+fn test_hive_dir_loads_and_counts_via_footers() {
+    let dir = tempfile::tempdir().unwrap();
+    let mk = |sub: &str, n: i64| {
+        let d = dir.path().join(sub);
+        std::fs::create_dir_all(&d).unwrap();
+        let mut df = df!("v" => (0..n).collect::<Vec<i64>>()).unwrap();
+        let f = File::create(d.join("data.parquet")).unwrap();
+        ParquetWriter::new(f).finish(&mut df).unwrap();
+    };
+    // Hive layout across two partition keys; 30 + 12 + 8 = 50 rows total.
+    mk("form_type=a/year=2020", 30);
+    mk("form_type=a/year=2021", 12);
+    mk("form_type=b/year=2020", 8);
+
+    let terminal_area = Rect::new(0, 0, 80, 30);
+    let (tx, rx) = mpsc::channel();
+    let mut app = App::new(tx.clone(), common::test_runtime());
+    let opts = OpenOptions {
+        hive: true,
+        ..OpenOptions::default()
+    };
+    pump_open_until_loaded(&mut app, &rx, vec![dir.path().to_path_buf()], opts);
+
+    // Drive render -> buffer collect -> background count to completion.
+    let mut counted = false;
+    for _ in 0..200 {
+        let mut buf = Buffer::empty(terminal_area);
+        app.render(terminal_area, &mut buf);
+        let needs = app
+            .data_table_state
+            .as_mut()
+            .map(|s| {
+                let n = s.needs_recollect;
+                s.needs_recollect = false;
+                n
+            })
+            .unwrap_or(false);
+        if needs {
+            app.spawn_async_collect("Loading buffer...");
+        }
+        while let Ok(ev) = rx.try_recv() {
+            if let Some(next) = app.event(&ev) {
+                let _ = tx.send(next);
+            }
+        }
+        counted = app
+            .data_table_state
+            .as_ref()
+            .and_then(|s| s.num_rows_if_valid())
+            == Some(50);
+        if !app.is_busy() && !needs && counted {
+            break;
+        }
+        std::thread::sleep(std::time::Duration::from_millis(5));
+    }
+
+    assert!(counted, "exact total should resolve to the footer sum (50)");
+    let state = app.data_table_state.as_ref().unwrap();
+    assert_eq!(state.num_rows, 50, "hive dir total should equal footer sum");
+    assert!(
+        state.display_slice_df().is_some(),
+        "first buffer should be populated"
+    );
+}


### PR DESCRIPTION
Opening a partitioned Parquet dir with `--hive` spun on "Loading buffer…" for minutes before showing anything. The first paint was gated on an exact `len()` over the whole set, and on a 474GB hive dir over NFS that count alone took minutes.

Two changes:

- First paint no longer waits for the count. We render a top-of-data window (`slice(0, N)`) immediately and compute the exact total in the background, filling in the scrollbar once it lands. The count is keyed to its own generation so scrolling during a long count doesn't restart it, and the tokio runtime shuts down in the background so quitting mid-count doesn't hang.
- The background count for a local hive dir now sums per-file Parquet footer `num_rows` (metadata only) instead of a data scan — ~0.6s for 2.9M rows across 8,597 files vs. minutes. Any filter/group/query falls back to `len()`; globs/remote/CSV are unchanged.

Tested: footer sum validated equal to a real `len()` on a sample partition; new unit + integration tests cover the count and the hive load path.