### PR TITLE
Show binary columns as a stub instead of reading their blobs

### DIFF
--- a/crates/datui-lib/src/config.rs
+++ b/crates/datui-lib/src/config.rs
@@ -753,6 +753,8 @@ pub struct ColorConfig {
     pub float_col: String,
     pub bool_col: String,
     pub temporal_col: String,
+    /// Main data table: placeholder color for binary columns (the `‹binary›` stub)
+    pub binary_col: String,
     /// Chart view: series colors 1–7 (line/scatter/bar series)
     pub chart_series_color_1: String,
     pub chart_series_color_2: String,
@@ -818,6 +820,7 @@ const COLOR_COMMENTS: &[(&str, &str)] = &[
     ("float_col", "Main table: float column text color"),
     ("bool_col", "Main table: boolean column text color"),
     ("temporal_col", "Main table: date/datetime/time column text color"),
+    ("binary_col", "Main table: binary column placeholder color"),
     ("chart_series_color_1", "Chart view: first series color"),
     ("chart_series_color_2", "Chart view: second series color"),
     ("chart_series_color_3", "Chart view: third series color"),
@@ -983,6 +986,7 @@ impl Default for ColorConfig {
             float_col: "blue".to_string(),
             bool_col: "yellow".to_string(),
             temporal_col: "magenta".to_string(),
+            binary_col: "dark_gray".to_string(),
             chart_series_color_1: "cyan".to_string(),
             chart_series_color_2: "magenta".to_string(),
             chart_series_color_3: "green".to_string(),
@@ -1416,6 +1420,9 @@ impl ColorConfig {
         if other.temporal_col != default.temporal_col {
             self.temporal_col = other.temporal_col;
         }
+        if other.binary_col != default.binary_col {
+            self.binary_col = other.binary_col;
+        }
         if other.chart_series_color_1 != default.chart_series_color_1 {
             self.chart_series_color_1 = other.chart_series_color_1;
         }
@@ -1804,6 +1811,10 @@ impl Theme {
         colors.insert(
             "temporal_col".to_string(),
             parser.parse(&config.colors.temporal_col)?,
+        );
+        colors.insert(
+            "binary_col".to_string(),
+            parser.parse(&config.colors.binary_col)?,
         );
         colors.insert(
             "chart_series_color_1".to_string(),

--- a/crates/datui-lib/src/render/context.rs
+++ b/crates/datui-lib/src/render/context.rs
@@ -35,6 +35,9 @@ pub struct RenderContext {
     pub float_col: Color,
     pub bool_col: Color,
     pub temporal_col: Color,
+    /// Placeholder color for binary-column cells. Applied regardless of `column_colors` since the
+    /// `‹binary›` stub is a placeholder, not data.
+    pub binary_col: Color,
 
     pub table_cell_padding: u16,
     pub column_colors: bool,
@@ -99,6 +102,7 @@ impl RenderContext {
             } else {
                 Color::Reset
             },
+            binary_col: theme.get("binary_col"),
 
             table_cell_padding,
             column_colors,

--- a/crates/datui-lib/src/render/datatable_main.rs
+++ b/crates/datui-lib/src/render/datatable_main.rs
@@ -120,7 +120,9 @@ pub fn render(
                     ctx.column_separator,
                 )
                 .with_cell_padding(ctx.table_cell_padding)
-                .with_alternate_row_bg(ctx.alternate_row_color);
+                .with_alternate_row_bg(ctx.alternate_row_color)
+                .with_binary_col(ctx.binary_col)
+                .with_binary_columns(state.binary_column_names());
             if ctx.column_colors {
                 dt = dt.with_column_type_colors(
                     ctx.str_col,

--- a/crates/datui-lib/src/widgets/datatable.rs
+++ b/crates/datui-lib/src/widgets/datatable.rs
@@ -2849,6 +2849,22 @@ impl DataTableState {
     ///
     /// Caller must ensure `num_rows_valid` (via `set_num_rows`) before calling.
     /// `num_rows_override`, when supplied, applies that value first.
+    /// Column expressions for the display buffer, in `column_order`. Binary columns are replaced
+    /// by a stub literal ([`BINARY_STUB`]) so their blobs are never read — keeping scroll/jump
+    /// collects fast. The full bytes stay available through `lf` for export and analysis.
+    fn display_column_exprs(&self) -> Vec<Expr> {
+        self.column_order
+            .iter()
+            .map(|name| {
+                if matches!(self.schema.get(name.as_str()), Some(DataType::Binary)) {
+                    lit(BINARY_STUB).alias(name.as_str())
+                } else {
+                    col(name.as_str())
+                }
+            })
+            .collect()
+    }
+
     pub fn prepare_async_collect(
         &mut self,
         num_rows_override: Option<usize>,
@@ -2979,11 +2995,7 @@ impl DataTableState {
             return None;
         }
 
-        let all_columns: Vec<_> = self
-            .column_order
-            .iter()
-            .map(|name| col(name.as_str()))
-            .collect();
+        let all_columns = self.display_column_exprs();
         let lf = self
             .lf
             .clone()
@@ -3203,11 +3215,7 @@ impl DataTableState {
             return;
         }
 
-        let all_columns: Vec<_> = self
-            .column_order
-            .iter()
-            .map(|name| col(name.as_str()))
-            .collect();
+        let all_columns = self.display_column_exprs();
 
         let use_streaming = self.polars_streaming;
         let full_df = match collect_lazy(
@@ -4361,6 +4369,11 @@ struct RowNumbersParams {
     row_start_index: usize,
     selected_row: Option<usize>,
 }
+
+/// Placeholder shown in the table for binary columns. Their values (often large blobs, e.g.
+/// raw document bytes) are never read into the display buffer — only this stub is — which keeps
+/// scrolling and jump-to-end fast. The real bytes remain in `lf` for export/analysis.
+const BINARY_STUB: &str = "‹binary›";
 
 /// Whether a column whose value doesn't fully fit may be shown truncated. Textual columns
 /// (strings, raw bytes, categorical/enum labels) are fine to clip — a partial value still reads
@@ -6078,6 +6091,31 @@ mod tests {
             eff_end - eff_start,
             "df height must match range"
         );
+    }
+
+    #[test]
+    fn binary_columns_are_stubbed_in_display_buffer() {
+        // Binary columns must not be materialized into the display buffer (their blobs can be huge
+        // and reading them is what stalls jump-to-end); the buffer holds a stub instead.
+        let a = Series::new("a".into(), &[1i32, 2, 3]);
+        let blob = Series::new("blob".into(), &["aaaa", "bbbb", "cccc"])
+            .cast(&DataType::Binary)
+            .unwrap();
+        let lf = DataFrame::new(vec![a.into(), blob.into()]).unwrap().lazy();
+        let mut state = DataTableState::new(lf, None, None, None, None, true).unwrap();
+        state.visible_rows = 10;
+        state.collect();
+
+        let df = state.df.as_ref().expect("display df present");
+        let col = df.column("blob").expect("blob column present in buffer");
+        assert_eq!(
+            col.dtype(),
+            &DataType::String,
+            "binary column should be stubbed (not read as binary)"
+        );
+        assert_eq!(col.str().unwrap().get(0).unwrap(), BINARY_STUB);
+        // A non-binary column is untouched.
+        assert_eq!(df.column("a").unwrap().dtype(), &DataType::Int32);
     }
 
     #[test]

--- a/crates/datui-lib/src/widgets/datatable.rs
+++ b/crates/datui-lib/src/widgets/datatable.rs
@@ -3604,6 +3604,16 @@ impl DataTableState {
             .collect()
     }
 
+    /// Names of binary columns in the source schema. Their values are not read into the display
+    /// buffer (the `‹binary›` stub stands in); the renderer uses this to style those cells.
+    pub fn binary_column_names(&self) -> std::collections::HashSet<String> {
+        self.schema
+            .iter()
+            .filter(|(_, dtype)| matches!(dtype, DataType::Binary))
+            .map(|(name, _)| name.to_string())
+            .collect()
+    }
+
     /// Estimated heap size in bytes of the currently buffered slice (locked + scrollable), if collected.
     pub fn buffered_memory_bytes(&self) -> Option<usize> {
         let locked = self
@@ -4340,6 +4350,12 @@ pub struct DataTable {
     pub float_col: Option<Color>,
     pub bool_col: Option<Color>,
     pub temporal_col: Option<Color>,
+    /// Color for binary-column placeholder cells (the `‹binary›` stub). Applied with italic,
+    /// independent of `column_colors`, so stubs always read as "placeholder, not data".
+    pub binary_col: Option<Color>,
+    /// Names of columns that are binary in the source schema. Their cells hold the `‹binary›`
+    /// stub (see [`BINARY_STUB`]) and are styled with `binary_col` + italic.
+    pub binary_cols: std::collections::HashSet<String>,
 }
 
 impl Default for DataTable {
@@ -4357,6 +4373,8 @@ impl Default for DataTable {
             float_col: None,
             bool_col: None,
             temporal_col: None,
+            binary_col: None,
+            binary_cols: std::collections::HashSet::new(),
         }
     }
 }
@@ -4433,6 +4451,18 @@ impl DataTable {
         self
     }
 
+    /// Set the color used for binary-column placeholder cells.
+    pub fn with_binary_col(mut self, color: Color) -> Self {
+        self.binary_col = Some(color);
+        self
+    }
+
+    /// Set the names of binary columns, whose cells render the `‹binary›` stub.
+    pub fn with_binary_columns(mut self, names: std::collections::HashSet<String>) -> Self {
+        self.binary_cols = names;
+        self
+    }
+
     /// Return the color for a column dtype when column_colors is enabled.
     fn column_type_color(&self, dtype: &DataType) -> Option<Color> {
         if !self.column_colors {
@@ -4491,10 +4521,23 @@ impl DataTable {
             0
         });
 
+        let col_names = df.get_column_names();
         for col_index in 0..cols {
             let mut max_len = widths[col_index];
             let col_data = &df[col_index];
-            let col_color = self.column_type_color(col_data.dtype());
+            // Binary columns hold the `‹binary›` stub: style them with binary_col + italic so they
+            // read as a placeholder rather than data, regardless of the column_colors setting.
+            let is_binary = self.binary_cols.contains(col_names[col_index].as_str());
+            let cell_style = if is_binary {
+                let mut s = Style::default().add_modifier(Modifier::ITALIC);
+                if let Some(c) = self.binary_col {
+                    s = s.fg(c);
+                }
+                Some(s)
+            } else {
+                self.column_type_color(col_data.dtype())
+                    .map(|c| Style::default().fg(c))
+            };
 
             for (row_index, row) in rows.iter_mut().take(max_rows).enumerate() {
                 let value = col_data.get(row_index).unwrap();
@@ -4505,11 +4548,8 @@ impl DataTable {
                 };
                 let len = val_str.chars().count() as u16;
                 max_len = max_len.max(len);
-                let cell = match col_color {
-                    Some(c) => Cell::from(Line::from(Span::styled(
-                        val_str.into_owned(),
-                        Style::default().fg(c),
-                    ))),
+                let cell = match cell_style {
+                    Some(s) => Cell::from(Line::from(Span::styled(val_str.into_owned(), s))),
                     None => Cell::from(Line::from(val_str)),
                 };
                 row.push(cell);
@@ -6028,6 +6068,46 @@ mod tests {
             header_row_string(&buf, area).contains("wide"),
             "truncated column heading should be visible: {:?}",
             header_row_string(&buf, area)
+        );
+    }
+
+    #[test]
+    fn binary_stub_cells_are_styled_with_binary_color_and_italic() {
+        // Binary columns render the `‹binary›` stub; those cells should be colored with
+        // binary_col and italicized so they read as a placeholder, while ordinary columns
+        // keep their normal (non-italic) styling.
+        let table = DataTable {
+            binary_col: Some(Color::DarkGray),
+            binary_cols: std::collections::HashSet::from(["blob".to_string()]),
+            ..DataTable::default()
+        };
+        let df = df!(
+            "a" => &[1i32, 2],
+            "blob" => &[BINARY_STUB, BINARY_STUB],
+        )
+        .unwrap();
+        let area = Rect::new(0, 0, 20, 4);
+        let mut buf = Buffer::empty(area);
+        let mut ts = TableState::default();
+        table.render_dataframe(&df, area, &mut buf, &mut ts, false, 0);
+
+        // A data row (y = 1; y = 0 is the header). The stub cells should be dark gray + italic.
+        let stub_styled = (area.x..area.x + area.width).any(|x| {
+            let cell = &buf[(x, 1)];
+            cell.fg == Color::DarkGray && cell.modifier.contains(Modifier::ITALIC)
+        });
+        assert!(
+            stub_styled,
+            "binary stub cells should be colored with binary_col and italicized"
+        );
+        // The non-binary "a" column must not be italicized.
+        let any_italic_non_darkgray = (area.x..area.x + area.width).any(|x| {
+            let cell = &buf[(x, 1)];
+            cell.modifier.contains(Modifier::ITALIC) && cell.fg != Color::DarkGray
+        });
+        assert!(
+            !any_italic_non_darkgray,
+            "only binary columns should be italicized"
         );
     }
 

--- a/docs/user-guide/configuration.md
+++ b/docs/user-guide/configuration.md
@@ -321,6 +321,7 @@ int_col = "#8be9fd"                    # Cyan
 float_col = "#bd93f9"                  # Purple
 bool_col = "#f1fa8c"                  # Yellow
 temporal_col = "#ff79c6"               # Pink
+binary_col = "dark_gray"               # Binary column ‹binary› placeholder (always applied, shown italic)
 
 # Borders and modals
 sidebar_border = "#6272a4"             # Comment

--- a/docs/user-guide/loading-data.md
+++ b/docs/user-guide/loading-data.md
@@ -142,6 +142,10 @@ If you pass an S3 or `gs://` URI to a binary built that way, you will see an err
 
 **CSV date inference** — By default, CSV string columns that look like dates (e.g. `YYYY-MM-DD`, `YYYY-MM-DDTHH:MM:SS`) are parsed as Polars Date/Datetime. Use `--parse-dates false` or set `parse_dates = false` in [configuration](configuration.md) to disable.
 
+## Binary columns
+
+Binary (blob) columns often hold large values (e.g. raw document bytes) that are slow to read and not meaningful to print. The table shows a `‹binary›` placeholder instead of the bytes — rendered dim and italic — so scrolling and jump-to-end stay fast. The underlying bytes are still read for exports and analysis. Customize the placeholder color with `binary_col` in [configuration](configuration.md).
+
 ## Compression
 
 Compressed files are identified by extension and decompressed before loading. Use the `--compression` option to specify the format when the file has no extension or the extension is wrong.

--- a/tests/color_parser_test.rs
+++ b/tests/color_parser_test.rs
@@ -327,6 +327,7 @@ fn test_theme_with_custom_colors() {
         float_col: "blue".to_string(),
         bool_col: "yellow".to_string(),
         temporal_col: "magenta".to_string(),
+        binary_col: "dark_gray".to_string(),
         chart_series_color_1: "cyan".to_string(),
         chart_series_color_2: "magenta".to_string(),
         chart_series_color_3: "green".to_string(),


### PR DESCRIPTION
Render binary (blob) columns in the data table as a distinct dim-italic placeholder (\`‹binary›\`) instead of reading their bytes into the display buffer. Reading large blobs (e.g. raw document bytes across many partitions) is what stalled scrolling and jump-to-end; the buffer now holds a stub while the real bytes remain in \`lf\` for export.

Includes a \`binary_col\` style config key and documentation.

## Commits
- Show a stub for binary columns instead of reading their blobs
- Render binary column stubs in a distinct dim italic style
- Document binary column placeholder and binary_col config key