### PR TITLE
Stop analysis tools from reading binary blobs

### DIFF
--- a/crates/datui-lib/src/lib.rs
+++ b/crates/datui-lib/src/lib.rs
@@ -7283,8 +7283,10 @@ impl App {
                 self.handle_scroll(|s| s.scroll_to_row_centered(n))
             }
             AppEvent::AnalysisChunk => {
+                // Stub out binary columns: their blobs are never read for analysis (reading
+                // multi-GB blobs across partitions can exhaust memory and freeze the process).
                 let lf = match &self.data_table_state {
-                    Some(state) => state.lf.clone(),
+                    Some(state) => state.lf.clone().select(state.binary_stub_exprs()),
                     None => {
                         self.analysis_computation = None;
                         self.analysis_modal.computing = None;
@@ -7346,7 +7348,8 @@ impl App {
             }
             AppEvent::AnalysisDistributionCompute => {
                 if let Some(state) = &self.data_table_state {
-                    let lf = state.lf.clone();
+                    // Stub binary columns so their blobs are never materialized (see AnalysisChunk).
+                    let lf = state.lf.clone().select(state.binary_stub_exprs());
                     let sampling = self.sampling_threshold;
                     let seed = self.analysis_modal.random_seed;
                     let streaming = self.app_config.performance.polars_streaming;
@@ -7384,7 +7387,8 @@ impl App {
             }
             AppEvent::AnalysisCorrelationCompute => {
                 if let Some(state) = &self.data_table_state {
-                    let lf = state.lf.clone();
+                    // Stub binary columns so their blobs are never materialized (see AnalysisChunk).
+                    let lf = state.lf.clone().select(state.binary_stub_exprs());
                     let streaming = state.polars_streaming;
                     let seed = self.analysis_modal.random_seed;
                     self.spawn_bg("Computing correlation matrix...", move |gen, tx| {

--- a/crates/datui-lib/src/widgets/datatable.rs
+++ b/crates/datui-lib/src/widgets/datatable.rs
@@ -2849,10 +2849,12 @@ impl DataTableState {
     ///
     /// Caller must ensure `num_rows_valid` (via `set_num_rows`) before calling.
     /// `num_rows_override`, when supplied, applies that value first.
-    /// Column expressions for the display buffer, in `column_order`. Binary columns are replaced
-    /// by a stub literal ([`BINARY_STUB`]) so their blobs are never read — keeping scroll/jump
-    /// collects fast. The full bytes stay available through `lf` for export and analysis.
-    fn display_column_exprs(&self) -> Vec<Expr> {
+    /// Column expressions for every column in `column_order`, with binary columns replaced by a
+    /// stub literal ([`BINARY_STUB`]) so their blobs are never read. Used both for the display
+    /// buffer (keeps scroll/jump collects fast) and for analysis (describe/distribution/
+    /// correlation), where reading multi-GB blobs across partitions would otherwise exhaust
+    /// memory and freeze the process. The full bytes stay available through `lf` for export.
+    pub(crate) fn binary_stub_exprs(&self) -> Vec<Expr> {
         self.column_order
             .iter()
             .map(|name| {
@@ -2995,7 +2997,7 @@ impl DataTableState {
             return None;
         }
 
-        let all_columns = self.display_column_exprs();
+        let all_columns = self.binary_stub_exprs();
         let lf = self
             .lf
             .clone()
@@ -3215,7 +3217,7 @@ impl DataTableState {
             return;
         }
 
-        let all_columns = self.display_column_exprs();
+        let all_columns = self.binary_stub_exprs();
 
         let use_streaming = self.polars_streaming;
         let full_df = match collect_lazy(
@@ -6196,6 +6198,46 @@ mod tests {
         assert_eq!(col.str().unwrap().get(0).unwrap(), BINARY_STUB);
         // A non-binary column is untouched.
         assert_eq!(df.column("a").unwrap().dtype(), &DataType::Int32);
+    }
+
+    #[test]
+    fn analysis_describe_stubs_binary_columns_without_reading_blobs() {
+        // Describe (and the other analysis tools) route the frame through `binary_stub_exprs`
+        // so binary blobs are never materialized — reading multi-GB blobs across partitions is
+        // what froze the process. The binary column still appears, as a stub.
+        let a = Series::new("a".into(), &[1i32, 2, 3]);
+        let blob = Series::new("blob".into(), &["aaaa", "bbbb", "cccc"])
+            .cast(&DataType::Binary)
+            .unwrap();
+        let lf = DataFrame::new(vec![a.into(), blob.into()]).unwrap().lazy();
+        let state = DataTableState::new(lf, None, None, None, None, true).unwrap();
+
+        let analysis_lf = state.lf.clone().select(state.binary_stub_exprs());
+        let results =
+            crate::statistics::compute_describe_from_lazy(&analysis_lf, 3, None, 0, false)
+                .expect("describe should not fail on binary columns");
+
+        let blob_stat = results
+            .column_statistics
+            .iter()
+            .find(|c| c.name == "blob")
+            .expect("binary column present in describe");
+        // Stubbed to a constant string, so describe treats it as categorical and its min/max is
+        // the stub — never the raw bytes.
+        assert_eq!(blob_stat.dtype, DataType::String);
+        let cat = blob_stat
+            .categorical_stats
+            .as_ref()
+            .expect("stubbed binary column has categorical stats");
+        assert_eq!(cat.min.as_deref(), Some(BINARY_STUB));
+        assert_eq!(cat.max.as_deref(), Some(BINARY_STUB));
+        // The numeric column is still described normally.
+        let a_stat = results
+            .column_statistics
+            .iter()
+            .find(|c| c.name == "a")
+            .expect("numeric column present in describe");
+        assert!(a_stat.numeric_stats.is_some());
     }
 
     #[test]


### PR DESCRIPTION
Stacked on #48.

## Problem
Opening a large partitioned dataset and running an analysis tool (Describe, Distribution, or Correlation) made the program **uninterruptible** — `q`, Ctrl-C, and Ctrl-Z all did nothing, and the process had to be killed by PID. On a cloud-backed dataset this is also expensive (egresses every blob).

The freeze is not an event-loop bug — the loop stays responsive and allows quit while busy. The cause is that all three analysis tools collected the full \`LazyFrame\` **including \`Binary\` columns**:
- Describe — \`build_describe_aggregation_exprs\` aggregates every column
- Distribution — \`compute_statistics_with_options\` collects/samples the whole frame
- Correlation — \`collect_lazy(lf)\` over all columns

Those \`Binary\` columns hold multi-GB blobs, so the collect read every blob across every partition, exhausting memory until the process thrashed and could no longer service input. (Ctrl-C/Ctrl-Z are no-ops in raw mode regardless.)

\`#48\` stubbed binary columns in the *display* buffer but never the *statistics* path.

## Fix
Route the analysis \`LazyFrame\` through the same binary-stub expressions the display buffer already uses (renamed \`display_column_exprs\` → \`binary_stub_exprs\`, now \`pub(crate)\`). Binary columns become a constant \`‹binary›\` string that is never read from disk:
- No blob reads → no OOM → no freeze, across all three analysis tools
- No cloud egress of blob bytes
- Binary columns still appear in describe, as a stub (real count, min/max = \`‹binary›\`) — no changes needed in \`statistics.rs\` or rendering

## Scope note
This does **not** make a legitimately-expensive analysis (e.g. describe over a huge all-numeric dataset) cancellable — Polars \`collect()\` can't be aborted mid-flight today. That's deferred follow-up.

## Test plan
- [x] Added \`analysis_describe_stubs_binary_columns_without_reading_blobs\` — asserts describe yields the stub instead of reading the bytes
- [x] \`cargo test -p datui-lib\` — 187 passed
- [ ] Manual: open the partitioned dataset with blob columns, run Describe — completes promptly, binary column shows \`‹binary›\`