### PR TITLE
Fix nightly build: bump ethnum to 1.5.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1404,9 +1404,9 @@ dependencies = [
 
 [[package]]
 name = "ethnum"
-version = "1.5.1"
+version = "1.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0939f82868b77ef93ce3c3c3daf2b3c526b456741da5a1a4559e590965b6026b"
+checksum = "40404c3f5f511ec4da6fe866ddf6a717c309fdbb69fbbad7b0f3edab8f2e835f"
 
 [[package]]
 name = "event-listener"

--- a/crates/datui-pyo3/Cargo.lock
+++ b/crates/datui-pyo3/Cargo.lock
@@ -1159,14 +1159,14 @@ dependencies = [
 
 [[package]]
 name = "datui-cli"
-version = "0.2.53-dev"
+version = "0.2.56-dev"
 dependencies = [
  "clap",
 ]
 
 [[package]]
 name = "datui-lib"
-version = "0.2.53-dev"
+version = "0.2.56-dev"
 dependencies = [
  "arrow",
  "bzip2",
@@ -1201,7 +1201,7 @@ dependencies = [
 
 [[package]]
 name = "datui-pyo3"
-version = "0.2.53-dev"
+version = "0.2.56-dev"
 dependencies = [
  "bincode",
  "datui-lib",
@@ -1394,9 +1394,9 @@ dependencies = [
 
 [[package]]
 name = "ethnum"
-version = "1.5.2"
+version = "1.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca81e6b4777c89fd810c25a4be2b1bd93ea034fbe58e6a75216a34c6b82c539b"
+checksum = "40404c3f5f511ec4da6fe866ddf6a717c309fdbb69fbbad7b0f3edab8f2e835f"
 
 [[package]]
 name = "event-listener"


### PR DESCRIPTION
## Problem


\`\`\`
error[E0512]: cannot transmute between types of different sizes, or dependently-sized types
  --> ethnum-1.5.1/src/error.rs:16:14
   note: target type: \`TryFromIntError\` (8 bits)
error: could not compile \`ethnum\` (lib) due to 1 previous error
\`\`\`

\`ethnum\` v1.5.1 (a transitive dependency via polars) contains an invalid \`transmute\` in its error handling. A recent Rust **stable** release changed the layout of \`std::num::TryFromIntError\`, so the transmute no longer type-checks and the crate fails to build.


## Fix

\`cargo update -p ethnum\` → **1.5.1 → 1.5.3** (1.5.2+ fixes the transmute). Lockfile-only, semver-compatible bump; no \`Cargo.toml\` change. This keeps us building on current stable rather than pinning around the problem.

## Verification

- \`cargo build --release\` succeeds locally on \`rustc 1.95.0\`; \`ethnum v1.5.3\` compiles cleanly.
