### PR TITLE
Fail fast with recovery steps when winget fork sync is blocked

### DIFF
--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -222,6 +222,44 @@ jobs:
     runs-on: windows-latest
     # winget-releaser fetches release assets via GitHub API; no local download needed
     steps:
+      # Preflight. winget-releaser runs `komac sync-fork` to fast-forward our
+      # winget-pkgs fork from upstream before opening the PR. WINGET_TOKEN is a classic
+      # PAT with `public_repo` scope only, and GitHub refuses any ref update that
+      # creates or updates files under `.github/workflows/` unless the token also has
+      # `workflow` scope -- which upstream winget-pkgs changes every few weeks. komac
+      # reports that as "does not have the correct permissions to execute `UpdateRef`",
+      # which reads like an expired/invalid token and sends you rotating secrets.
+      #
+      # Adding `workflow` scope is not an option: GitHub's classic-PAT UI force-selects
+      # full `repo` (private repos included) alongside it. So do the sync here with the
+      # same token, and when it's blocked, fail immediately with the actual recovery
+      # steps instead of three retries of a misleading error.
+      #
+      # Fork distance is only the trigger, not the cause: the longer the gap between
+      # releases, the likelier upstream touched a workflow file. Back-to-back releases
+      # sync cleanly; a quiet stretch is what breaks it.
+      - name: Sync winget-pkgs fork (preflight)
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.WINGET_TOKEN }}
+          FORK: derekwisong/winget-pkgs
+        run: |
+          set -uo pipefail
+          echo "Fast-forwarding $FORK master from microsoft/winget-pkgs..."
+          if out=$(gh api "repos/$FORK/merge-upstream" -f branch=master 2>&1); then
+            echo "$out"
+            echo "Fork is in sync; handing off to winget-releaser."
+            exit 0
+          fi
+          echo "$out"
+          if grep -qi 'without .workflow. scope' <<<"$out"; then
+            echo "::error title=winget fork sync blocked::WINGET_TOKEN lacks 'workflow' scope and upstream changed .github/workflows. RECOVER: open https://github.com/${FORK} and click 'Sync fork' -> 'Update branch', then re-run only the failed job with 'gh run rerun ${GITHUB_RUN_ID} --failed'. Do NOT rotate WINGET_TOKEN -- it is valid; this is a scope restriction, not an auth failure. Details: docs/for-developers/packaging.md#winget-releases"
+            exit 1
+          fi
+          # Anything else (transient 5xx, rate limit, unexpected fork state) is not
+          # provably fatal -- komac may still succeed, and it retries 3x below.
+          echo "::warning title=winget fork sync failed::Could not fast-forward the fork (see log above). Continuing anyway; winget-releaser may still succeed."
+
       # Retried up to 3x: komac's GitHub GraphQL mutations intermittently fail
       # with "Ref cannot be created" or "Something went wrong while executing
       # your query" (transient server-side / secondary-rate-limit hiccups, not

--- a/docs/for-developers/packaging.md
+++ b/docs/for-developers/packaging.md
@@ -126,6 +126,55 @@ The release workflow can push PKGBUILD and .SRCINFO to the AUR automatically whe
 
 If these secrets are not set, the "Publish to AUR" step will fail. To disable automated AUR updates, remove or comment out that step in `.github/workflows/release.yml`.
 
+## WinGet releases
+
+The `publish-winget` job in `.github/workflows/publish-packages.yml` uses
+[winget-releaser](https://github.com/vedantmgoyal9/winget-releaser), which drives
+[komac](https://github.com/russellbanks/Komac) to open a manifest PR against
+[microsoft/winget-pkgs](https://github.com/microsoft/winget-pkgs) from our fork at
+`derekwisong/winget-pkgs`.
+
+**Required repository secret:**
+
+| Secret | Description |
+|--------|-------------|
+| `WINGET_TOKEN` | Classic PAT with `public_repo` scope. Fine-grained PATs do not work — they cannot open a cross-fork PR against a repo you don't own. |
+
+At least one version of `derekwisong.datui` must already exist in winget-pkgs; the
+action refuses to create a brand-new package.
+
+### Recovering from "does not have the correct permissions to execute `UpdateRef`"
+
+Before opening the PR, komac fast-forwards our fork from upstream. GitHub blocks any
+ref update that touches `.github/workflows/` unless the token carries `workflow`
+scope, and upstream winget-pkgs edits its own workflows every few weeks — so the sync
+fails once enough time has passed since the last release. The error names a
+permissions problem, but **`WINGET_TOKEN` is fine; do not rotate it.**
+
+We can't just add the scope: GitHub's classic-PAT UI force-selects full `repo`
+(private repos included) whenever `workflow` is checked.
+
+The preflight step attempts the sync itself and, when blocked, fails fast with these
+steps in the job log:
+
+1. Open <https://github.com/derekwisong/winget-pkgs> and click **Sync fork** →
+   **Update branch**. A browser session has permissions the PAT doesn't.
+2. Re-run just the failed job:
+   ```bash
+   gh run rerun <run-id> --failed
+   ```
+3. Confirm the PR opened:
+   ```bash
+   gh pr list --repo microsoft/winget-pkgs --author derekwisong
+   ```
+
+Being a few commits behind upstream at job start is harmless — winget-pkgs merges
+manifest PRs constantly and those never touch workflow files.
+
+If this becomes a recurring nuisance, the durable fix is a dedicated machine account
+that owns the fork and holds a `repo` + `workflow` PAT (full `repo` scope is harmless
+on an account with no private repos), wired up via the action's `fork-user` input.
+
 ## More Information
 
 For detailed information about packaging metadata, policies, and AUR submission, see


### PR DESCRIPTION
## Background

The `publish-winget` job in the v0.2.56 release failed all three attempts with:

```
0: derekwisong does not have the correct permissions to execute `UpdateRef`
1: failed to sync upstream changes
```

That reads like an expired or invalid `WINGET_TOKEN`, but it isn't. The real error is visible only by calling the sync endpoint directly:

```
$ gh api repos/derekwisong/winget-pkgs/merge-upstream -f branch=master
422: refusing to allow an OAuth App to create or update workflow
     `.github/workflows/manifest-validation-diagnosis.lock.yml` without `workflow` scope
```

`WINGET_TOKEN` is a classic PAT with `public_repo` scope. GitHub refuses any ref update that creates or updates files under `.github/workflows/` unless the token also carries `workflow` scope, and upstream winget-pkgs edits its own workflows every few weeks. komac's `sync-fork` hits that and surfaces it as a permissions error naming our account.

Fork distance is the trigger, not the cause — the longer the gap between releases, the likelier upstream touched a workflow file. This is why 0.2.46 through 0.2.55 published fine and 0.2.56 broke after a two-month gap (25,808 commits behind).

Granting the scope isn't an option: GitHub's classic-PAT UI force-selects full `repo` (private repos included) whenever `workflow` is checked.

## Change

- Preflight step that performs the fork sync with the same token before `winget-releaser` runs. On the `workflow`-scope 422 it fails immediately with an `::error::` annotation carrying the actual recovery steps (sync the fork from the web UI, then `gh run rerun <id> --failed`) and an explicit "do not rotate the token". Any other sync failure only warns, since komac may still succeed and already retries 3x.
- Runbook section in `docs/for-developers/packaging.md` covering the WinGet flow, the required secret, this failure mode, and the recovery — plus the durable fix if it recurs (a machine account owning the fork with a `repo` + `workflow` PAT, wired via the action's `fork-user` input).

No change to the retry structure or the SHA-pinned action.

## Testing

- `publish-packages.yml` parses; `publish-winget` step order confirmed with the preflight first.
- Guard's branch logic exercised against the verbatim 422 string above (takes the fail-fast path) and against a transient `Something went wrong executing your query` error (falls through to the warning, no false positive).
- The underlying recovery was validated live on this release: fork synced via the web UI, `gh run rerun 31494551734 --failed` passed, and https://github.com/microsoft/winget-pkgs/pull/415656 opened for 0.2.56.

The preflight itself can't run until the next release tag, since `publish-winget` only runs on release.