### PR TITLE
Embed Windows VERSIONINFO resource in datui.exe

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -205,6 +205,17 @@ jobs:
         run: |
           if (!(Test-Path target\debug\datui.exe)) { Write-Error "Binary not found"; exit 1 }
 
+      - name: Verify version resource
+        run: |
+          $vi = (Get-Item target\debug\datui.exe).VersionInfo
+          Write-Host "ProductName=$($vi.ProductName) CompanyName=$($vi.CompanyName) FileVersion=$($vi.FileVersion)"
+          foreach ($field in 'ProductName','CompanyName','FileDescription','FileVersion','LegalCopyright') {
+            if ([string]::IsNullOrWhiteSpace($vi.$field)) {
+              Write-Error "VERSIONINFO field '$field' is empty - build.rs did not embed the resource"
+              exit 1
+            }
+          }
+
       - name: Bundle CLI for wheel
         run: |
           New-Item -ItemType Directory -Force -Path python/datui_bin

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -263,6 +263,17 @@ jobs:
       - name: Build release binary
         run: cargo build --release --locked -p datui
 
+      - name: Verify version resource
+        run: |
+          $vi = (Get-Item target/release/datui.exe).VersionInfo
+          Write-Host "ProductName=$($vi.ProductName) CompanyName=$($vi.CompanyName) FileVersion=$($vi.FileVersion)"
+          foreach ($field in 'ProductName','CompanyName','FileDescription','FileVersion','LegalCopyright') {
+            if ([string]::IsNullOrWhiteSpace($vi.$field)) {
+              Write-Error "VERSIONINFO field '$field' is empty - refusing to ship an anonymous binary"
+              exit 1
+            }
+          }
+
       - name: Bundle CLI for wheel
         run: |
           New-Item -ItemType Directory -Force -Path python/datui_bin

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1261,7 +1261,8 @@ dependencies = [
  "ratatui",
  "tempfile",
  "tokio",
- "toml",
+ "toml 0.8.23",
+ "winresource",
 ]
 
 [[package]]
@@ -1300,7 +1301,7 @@ dependencies = [
  "supports-color",
  "tempfile",
  "tokio",
- "toml",
+ "toml 0.8.23",
  "tui-textarea",
  "ureq",
  "xz2",
@@ -4232,6 +4233,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_spanned"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
 name = "serde_stacker"
 version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4731,9 +4741,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
 dependencies = [
  "serde",
- "serde_spanned",
- "toml_datetime",
+ "serde_spanned 0.6.9",
+ "toml_datetime 0.6.11",
  "toml_edit",
+]
+
+[[package]]
+name = "toml"
+version = "1.1.4+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3aace63f4bbcdfc2c965b059de67119c89c4017a70d633be6c104910f67056f5"
+dependencies = [
+ "indexmap",
+ "serde_core",
+ "serde_spanned 1.1.1",
+ "toml_datetime 1.1.1+spec-1.1.0",
+ "toml_parser",
+ "toml_writer",
+ "winnow 1.0.4",
 ]
 
 [[package]]
@@ -4746,6 +4771,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml_datetime"
+version = "1.1.1+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
 name = "toml_edit"
 version = "0.22.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4753,10 +4787,19 @@ checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
 dependencies = [
  "indexmap",
  "serde",
- "serde_spanned",
- "toml_datetime",
+ "serde_spanned 0.6.9",
+ "toml_datetime 0.6.11",
  "toml_write",
- "winnow",
+ "winnow 0.7.14",
+]
+
+[[package]]
+name = "toml_parser"
+version = "1.1.3+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d38ac1cf9b95face32296c0a3ede1fdc270627c9d9c02a7274dd6d960dc4d56"
+dependencies = [
+ "winnow 1.0.4",
 ]
 
 [[package]]
@@ -4764,6 +4807,12 @@ name = "toml_write"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
+
+[[package]]
+name = "toml_writer"
+version = "1.1.2+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d56353a2a665ad0f41a421187180aab746c8c325620617ad883a99a1cbe66d2"
 
 [[package]]
 name = "tower"
@@ -5466,6 +5515,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a5364e9d77fcdeeaa6062ced926ee3381faa2ee02d3eb83a5c27a8825540829"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "winnow"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b97319f7b8343df12cc98938e5c3eb436064524c8d2b4e30a1d3a36eecdf81"
+
+[[package]]
+name = "winresource"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0986a8b1d586b7d3e4fe3d9ea39fb451ae22869dcea4aa109d287a374d866087"
+dependencies = [
+ "toml 1.1.4+spec-1.1.0",
+ "version_check",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,11 @@ clap = { version = "4.5.54", features = ["derive"] }
 clap_mangen = "0.2"
 datui-cli = { path = "crates/datui-cli", version = "0.2.57-dev" }
 
+# Embeds the VERSIONINFO resource in datui.exe. Host-gated: only pulled in when
+# building on Windows, where the MSVC toolchain provides the resource compiler.
+[target.'cfg(windows)'.build-dependencies]
+winresource = "0.1.31"
+
 [dev-dependencies]
 # For integration tests (tests/*.rs) that use polars and config parsing
 polars = { version = "0.52", features = ["lazy"] }

--- a/build.rs
+++ b/build.rs
@@ -5,6 +5,30 @@ use std::fs;
 use std::io;
 use std::path::PathBuf;
 
+/// Embed a Windows VERSIONINFO resource in `datui.exe`.
+///
+/// Without this the binary ships with an empty resource directory: no product
+/// name, company, or description in the file's Properties dialog. Reputation
+/// based scanners treat anonymous binaries as lower trust, and users have no
+/// way to confirm what they downloaded.
+#[cfg(windows)]
+fn embed_version_resource() -> io::Result<()> {
+    // FileVersion and ProductVersion are derived from CARGO_PKG_VERSION.
+    let mut res = winresource::WindowsResource::new();
+    res.set("ProductName", "datui")
+        .set("FileDescription", env!("CARGO_PKG_DESCRIPTION"))
+        .set("CompanyName", "Derek Wisong")
+        .set("LegalCopyright", "Copyright (c) 2026 Derek Wisong")
+        .set("InternalName", "datui")
+        .set("OriginalFilename", "datui.exe");
+    res.compile()
+}
+
+#[cfg(not(windows))]
+fn embed_version_resource() -> io::Result<()> {
+    Ok(())
+}
+
 fn main() -> io::Result<()> {
     let cmd = datui_cli::Args::command();
     let man = Man::new(cmd);
@@ -22,6 +46,8 @@ fn main() -> io::Result<()> {
             fs::write(&release_manpage, &buffer)?;
         }
     }
+
+    embed_version_resource()?;
 
     Ok(())
 }


### PR DESCRIPTION
## What

The shipped Windows binary has an empty PE resource directory. Parsing the data directories of the released `datui.exe` from v0.2.56:

```
Certificate  0x0  0     <- unsigned
Resource     0x0  0     <- no VERSIONINFO
```

No ProductName, CompanyName, FileDescription, FileVersion or LegalCopyright — the Properties dialog in Explorer shows nothing, and users have no way to confirm what they downloaded.

This adds a `winresource`-driven VERSIONINFO block to `build.rs`, gated to Windows hosts (the MSVC toolchain supplies the resource compiler; the release workflow builds natively on `windows-latest`, so the gate is always satisfied there).

`FileVersion` / `ProductVersion` are derived from `CARGO_PKG_VERSION`, so they track releases automatically.

## Guardrail

Both the CI and release Windows jobs now read the metadata back off the built exe and fail if any field is empty, so this can't silently regress. The release check runs before the zip is created, so an anonymous binary can never be published.

## Context

Not a fix for the winget 0.2.56 Defender block — that traces to microsoft/winget-pkgs#399077, an open winget validation-pipeline bug where Defender fails during dynamic analysis and the failure is reported as a detection. Defender-error PRs in winget-pkgs went from ~10/month through June to 548 in August. This is general hardening: publisher metadata is worth having on its own, and anonymous binaries score worse with reputation-based scanners.

## Test plan

- [ ] CI Windows job passes and the new `Verify version resource` step prints non-empty `ProductName` / `CompanyName` / `FileVersion`
- [ ] Linux/macOS jobs unaffected (`build.rs` no-ops off-Windows)
- [ ] `cargo check --locked --workspace` clean (verified locally; Cargo.lock only gains `winresource` + its `toml` stack, no existing versions changed)