### PR TITLE
Keep symbol table in released binaries

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -93,7 +93,10 @@ files = [
 opt-level = 3
 
 [profile.release]
-strip = true
+# "debuginfo" rather than true/"symbols": keep .symtab so color-eyre can resolve
+# function names in panic backtraces from released binaries. Release already sets
+# debug = false, so there is no DWARF to carry -- this is symbol names only.
+strip = "debuginfo"
 lto = "thin"
 codegen-units = 1
 opt-level = 3

--- a/scripts/packaging/build_package.py
+++ b/scripts/packaging/build_package.py
@@ -128,6 +128,34 @@ def fix_aur_pkgbuild(repo_root: Path) -> bool:
     return True
 
 
+def add_pkgbuild_options(repo_root: Path) -> bool:
+    """Stop makepkg from stripping the released binary on the builder's machine.
+
+    The tarball ships a symbol table (see strip = "debuginfo" in Cargo.toml). Arch's
+    default OPTIONS has both strip and debug, so without this makepkg strips datui and
+    splits the symbols into a datui-bin-debug package -- which pacman marks --asdeps,
+    orphans immediately, and removes on the next -Rns cleanup. Either path loses the
+    backtraces, so opt out of both. Returns True on success.
+    """
+    pkgbuild = repo_root / "target" / "cargo-aur" / "PKGBUILD"
+
+    if not pkgbuild.exists():
+        return False
+
+    content = pkgbuild.read_text()
+
+    if "options=" in content:
+        return True  # cargo-aur emits its own now; don't fight it
+
+    if "\nsource=" not in content:
+        return False
+
+    content = content.replace("\nsource=", "\noptions=(!strip !debug)\nsource=", 1)
+    pkgbuild.write_text(content)
+    print("Added options=(!strip !debug) to PKGBUILD")
+    return True
+
+
 def main() -> int:
     parser = argparse.ArgumentParser(
         description="Build OS packages (deb, rpm, aur) for datui.",
@@ -216,6 +244,8 @@ def main() -> int:
     if args.pkg == "aur":
         if not fix_aur_pkgbuild(repo_root):
             sys.stderr.write("warning: failed to fix PKGBUILD for Arch compatibility\n")
+        if not add_pkgbuild_options(repo_root):
+            sys.stderr.write("warning: failed to add options=(!strip !debug) to PKGBUILD\n")
 
     # 6. Verify outputs and print paths
     if out_dir_or_aur == "aur":

--- a/scripts/packaging/build_package.py
+++ b/scripts/packaging/build_package.py
@@ -17,6 +17,11 @@ from __future__ import annotations
 
 import argparse
 import glob
+import hashlib
+import re
+import shutil
+import tarfile
+import tempfile
 import os
 import subprocess
 import sys
@@ -156,6 +161,93 @@ def add_pkgbuild_options(repo_root: Path) -> bool:
     return True
 
 
+def save_release_binary(repo_root: Path) -> Path | None:
+    """Snapshot target/release/datui before cargo-aur strips it in place.
+
+    cargo-aur runs `strip` directly on the release binary (src/main.rs, `strip(&binary)`)
+    before copying it into the tarball. That mutates the shared build output, so every
+    artifact produced after the AUR step -- notably the CLI bundled into the Python
+    wheel -- silently loses its symbol table. Keep a copy so we can put it back.
+    """
+    binary = repo_root / "target" / "release" / "datui"
+
+    if not binary.exists():
+        return None
+
+    backup = binary.with_name("datui.unstripped")
+    shutil.copy2(binary, backup)
+    return backup
+
+
+def restore_unstripped_binary(repo_root: Path, backup: Path) -> bool:
+    """Undo cargo-aur's strip: restore the binary and repack the AUR tarball.
+
+    Puts the unstripped binary back at target/release/datui (for later steps), swaps it
+    into the generated tarball, and refreshes the PKGBUILD sha256sum so it still matches
+    the tarball that gets uploaded to the release. Returns True on success.
+    """
+    if not backup.exists():
+        return False
+
+    aur_dir = repo_root / "target" / "cargo-aur"
+    binary = repo_root / "target" / "release" / "datui"
+
+    # 1. Restore the shared build output for downstream steps (wheel bundling).
+    shutil.copy2(backup, binary)
+
+    tarballs = list(aur_dir.glob("*.tar.gz"))
+    if len(tarballs) != 1:
+        sys.stderr.write(
+            f"warning: expected exactly 1 AUR tarball, found {len(tarballs)}; "
+            "leaving it stripped\n"
+        )
+        backup.unlink(missing_ok=True)
+        return False
+    tarball = tarballs[0]
+
+    # 2. Repack the tarball with the unstripped binary, preserving entry order/modes.
+    with tempfile.TemporaryDirectory() as tmp:
+        staging = Path(tmp) / "staging"
+        with tarfile.open(tarball, "r:gz") as tar:
+            members = tar.getnames()
+            tar.extractall(staging)
+
+        staged_binary = staging / "datui"
+        if not staged_binary.exists():
+            sys.stderr.write("warning: no 'datui' entry in AUR tarball; leaving it stripped\n")
+            backup.unlink(missing_ok=True)
+            return False
+
+        mode = staged_binary.stat().st_mode
+        shutil.copy2(backup, staged_binary)
+        staged_binary.chmod(mode)
+
+        with tarfile.open(tarball, "w:gz") as tar:
+            for name in members:
+                tar.add(staging / name, arcname=name, recursive=False)
+
+    # 3. Refresh the checksum in the PKGBUILD so it matches the repacked tarball.
+    pkgbuild = aur_dir / "PKGBUILD"
+    if pkgbuild.exists():
+        digest = hashlib.sha256(tarball.read_bytes()).hexdigest()
+        content = pkgbuild.read_text()
+        updated = re.sub(
+            r'sha256sums=\("[0-9a-f]{64}"\)',
+            f'sha256sums=("{digest}")',
+            content,
+            count=1,
+        )
+        if updated == content:
+            sys.stderr.write("warning: could not update sha256sums in PKGBUILD\n")
+            backup.unlink(missing_ok=True)
+            return False
+        pkgbuild.write_text(updated)
+        print(f"Repacked AUR tarball unstripped; sha256 now {digest[:16]}...")
+
+    backup.unlink(missing_ok=True)
+    return True
+
+
 def main() -> int:
     parser = argparse.ArgumentParser(
         description="Build OS packages (deb, rpm, aur) for datui.",
@@ -224,8 +316,11 @@ def main() -> int:
     # 4. Run packaging command (package datui for deb/rpm/aur)
     # Run from repo root; datui is the root package. cargo generate-rpm -p datui looks for
     # datui/Cargo.toml (wrong). cargo-aur does not support -p. So only deb uses -p datui.
+    saved_binary = None
     if args.pkg == "aur":
         cmd = ["cargo", "aur"]
+        # cargo-aur strips target/release/datui in place; snapshot it first.
+        saved_binary = save_release_binary(repo_root)
     elif args.pkg == "rpm":
         cmd = ["cargo", subcmd]
         override = rpm_version_override(repo_root)
@@ -246,6 +341,8 @@ def main() -> int:
             sys.stderr.write("warning: failed to fix PKGBUILD for Arch compatibility\n")
         if not add_pkgbuild_options(repo_root):
             sys.stderr.write("warning: failed to add options=(!strip !debug) to PKGBUILD\n")
+        if saved_binary is not None and not restore_unstripped_binary(repo_root, saved_binary):
+            sys.stderr.write("warning: AUR tarball left stripped by cargo-aur\n")
 
     # 6. Verify outputs and print paths
     if out_dir_or_aur == "aur":


### PR DESCRIPTION
Released binaries are built with `[profile.release] strip = true`, which drops `.symtab` as well as debug info. That affects every published artifact — `.deb`, `.rpm`, the AUR tarball, the Windows zip, both macOS tarballs, and the CLI binary bundled into all four wheels.

The cost is `color-eyre`. We depend on it and even tune `[profile.dev.package.backtrace] opt-level = 3` for it, but in a stripped release binary it has no symbol table to resolve against, so a user-reported panic renders as bare addresses:

```
0: 0x5581c4a2f1e3 - <unknown>
1: 0x5581c4a1b8a7 - <unknown>
```

Confirmed on the published 0.2.56 binary: no `.symtab`, only 229 `.dynsym` entries, all imported libc symbols.

## Change

`strip = "debuginfo"` instead. Release already sets `debug = false`, so there is no DWARF to carry — this keeps symbol names and nothing else. No runtime cost; the sections are not `PT_LOAD`ed.

## Size

The wheel already ships one unstripped Rust artifact, so this can be measured rather than guessed. In `datui-0.2.56-cp38-abi3-manylinux_2_39_x86_64.whl`:

| file | size | stripped? |
|---|---|---|
| `datui_bin/datui` | 73.6 MB | yes |
| `datui/_datui.abi3.so` | 130.8 MB | **no** — `datui-pyo3` is excluded from the workspace, so it never saw this profile |

Stripping that `.so` takes it to 89.5 MB, so symbols are 41.3 MB raw — but only **+4.0 MB deflated** (26.9 → 30.9 MB zipped), since `.strtab` is mangled Rust names and compresses ~10:1.

Predicted manylinux wheel: 56.6 MB → roughly **60 MB**, against PyPI's 100 MB per-file limit. Verified by dispatching `nightly.yml` on this branch and diffing wheel sizes against the baseline nightly on `main` — real numbers in a comment below.

## AUR

Arch's default `OPTIONS` contains both `strip` and `debug`, so shipping symbols upstream accomplishes nothing by itself: `makepkg` re-strips the binary and splits the symbols into a `datui-bin-debug` package, which `yay` installs `--asdeps`, pacman orphans instantly, and `-Rns` removes on the next update. `add_pkgbuild_options()` injects `options=(!strip !debug)` into the generated PKGBUILD to opt out of both.

It's a separate function rather than part of `fix_aur_pkgbuild()` because that one early-returns when the version has no `-dev`, making it a no-op on real releases. Injection is idempotent and defers to `cargo-aur` if it ever starts emitting its own `options=` line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qd9YNhGMzzK9JtYw8vAxsX
