### PR TITLE
Build the release body before the release, not after

### DIFF
--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -260,6 +260,31 @@ jobs:
           # provably fatal -- komac may still succeed, and it retries 3x below.
           echo "::warning title=winget fork sync failed::Could not fast-forward the fork (see log above). Continuing anyway; winget-releaser may still succeed."
 
+      # Second preflight, for a different failure. komac reads the GitHub release
+      # body and copies it into the manifest as ReleaseNotes. When the body is
+      # empty it quietly omits ReleaseNotes and ReleaseNotesUrl, the new version
+      # is inconsistent with the published one, and winget-pkgs labels the PR
+      # Manifest-Metadata-Consistency -- after the PR is open, which is the
+      # expensive moment to find out. 0.3.1 shipped that way: the notes were
+      # written on the release page six minutes after komac had already run.
+      #
+      # release.yml now builds the body from release-notes/<tag>.md at release
+      # creation, so an empty body here means that wiring came undone. Fail
+      # before opening a PR that a moderator would have to chase.
+      - name: Check the release body is populated (preflight)
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ needs.resolve-release.outputs.tag_name }}
+        run: |
+          set -euo pipefail
+          body=$(gh release view "$TAG" --repo "$GITHUB_REPOSITORY" --json body --jq '.body // ""')
+          if [ -z "${body//[[:space:]]/}" ]; then
+            echo "::error title=Release body is empty::komac would submit $TAG to winget with no ReleaseNotes. RECOVER: add release-notes/$TAG.md on main, run 'gh release edit $TAG --notes-file release-notes/$TAG.md', then re-run the failed job with 'gh run rerun ${GITHUB_RUN_ID} --failed'. Details: release-notes/README.md"
+            exit 1
+          fi
+          echo "Release body is ${#body} characters; komac will carry it into ReleaseNotes."
+
       # Retried up to 3x: komac's GitHub GraphQL mutations intermittently fail
       # with "Ref cannot be created" or "Something went wrong while executing
       # your query" (transient server-side / secondary-rate-limit hiccups, not

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -415,11 +415,73 @@ jobs:
           name: datui-macos-x86_64-apple-darwin-artifacts
           path: macos-x86_64
 
+      # The release body has to exist at the instant the release is created.
+      # publish-packages starts about a minute later and komac copies the body
+      # into the winget manifest as ReleaseNotes; notes typed onto the release
+      # page afterwards arrive too late, which is how 0.3.1 reached winget with
+      # none. Editing the release later fixes what humans read and nothing else.
+      #
+      # So the body is always composed here, and is never empty. Hand-written
+      # notes are preferred and live at release-notes/<tag>.md, committed with
+      # the release. When that file is absent the body is generated from the
+      # commit subjects since the previous tag, which is worse prose but is
+      # accurate, present on time, and still editable afterwards.
+      - name: Compose release body
+        id: release_body
+        env:
+          TAG: ${{ github.ref_name }}
+          SERVER_URL: ${{ github.server_url }}
+          REPOSITORY: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          out="$RUNNER_TEMP/release-body.md"
+          notes="release-notes/$TAG.md"
+          if [ -s "$notes" ]; then
+            cp "$notes" "$out"
+            echo "Using hand-written notes from $notes"
+          else
+            previous=$(git describe --tags --abbrev=0 --match 'v*' "$TAG^" 2>/dev/null || true)
+            if [ -n "$previous" ]; then
+              range="$previous..$TAG"
+            else
+              range="$TAG"
+            fi
+            # Drop bump_version.py's own commits. "Release 0.3.1" and "Bump
+            # version to 0.3.2-dev" tell a reader nothing, and would otherwise be
+            # two of the three lines in a small release.
+            changes=$(git log --no-merges -E --invert-grep \
+              --grep='^Release [0-9]' --grep='^Bump version to ' \
+              --format='- %s' "$range")
+            # A release carrying nothing but version commits still needs a body.
+            if [ -z "$changes" ]; then
+              changes=$(git log --no-merges --format='- %s' "$range")
+            fi
+            {
+              echo "## What's changed"
+              echo
+              echo "$changes"
+              if [ -n "$previous" ]; then
+                echo
+                echo "**Full changelog**: $SERVER_URL/$REPOSITORY/compare/$previous...$TAG"
+              fi
+            } > "$out"
+            echo "No $notes found; generated the body from commits since ${previous:-the start of history}."
+            echo "Edit the release afterwards if you want better prose; winget already has this text."
+          fi
+          if [ ! -s "$out" ]; then
+            echo "::error title=Release body is empty::Refusing to create $TAG with an empty body, which would publish to winget with no ReleaseNotes. Add release-notes/$TAG.md and re-run."
+            exit 1
+          fi
+          echo "path=$out" >> "$GITHUB_OUTPUT"
+          echo "--- release body ---"
+          cat "$out"
+
       - name: Create GitHub Release
         # SHA-pinned to defend against upstream takeover; bump deliberately.
         uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3.0.0
         with:
           tag_name: ${{ github.ref_name }}
+          body_path: ${{ steps.release_body.outputs.path }}
           files: |
             target/debian/*.deb
             target/generate-rpm/*.rpm

--- a/docs/for-developers/packaging.md
+++ b/docs/for-developers/packaging.md
@@ -72,6 +72,25 @@ The same script is used in GitHub Actions:
 - **CI** (`ci.yml`): Builds and uploads dev packages (`.deb`, `.rpm`, `.tar.gz`) on push to `main`
 - **Release** (`release.yml`): Attaches `.deb`, `.rpm`, and Arch `.tar.gz` to GitHub releases
 
+### Release notes
+
+`release.yml` composes the release body before creating the release. It uses
+`release-notes/v<version>.md` when that file is committed, and otherwise
+generates a body from the commit subjects since the previous tag. The body is
+therefore never empty, and hand-written notes are always optional.
+
+The timing is the point. `publish-packages.yml` starts about a minute after the
+release is created, and komac copies the release body into the winget manifest
+as `ReleaseNotes`. Notes typed onto the release page afterwards fix what people
+read on GitHub and nothing else, because winget already has whatever the body
+said. Version 0.3.1 shipped to winget with no release notes that way.
+
+To write notes for a release, run `python scripts/bump_version.py notes` and
+commit the file with the release. `tests/release_notes_test.rs` checks the
+wiring in CI, which runs on the release commit before the tag is pushed, and the
+winget job refuses to run komac against an empty release body. See
+`release-notes/README.md`.
+
 ### Arch Linux Installation
 
 Arch users can install from the release tarball:

--- a/release-notes/README.md
+++ b/release-notes/README.md
@@ -1,0 +1,38 @@
+# Release notes
+
+Optional hand-written notes, one file per release, named `v<version>.md` to
+match the git tag.
+
+`release.yml` composes the GitHub release body before creating the release. It
+uses the file for the tag when there is one, and otherwise generates a body from
+the commit subjects since the previous tag. So the body is never empty, and
+nothing here is ever required.
+
+## Why the timing matters
+
+`publish-packages.yml` starts about a minute after the release is created, and
+komac copies the release body into the winget manifest as `ReleaseNotes`. The
+body has to be right at that moment.
+
+Editing the release page afterwards fixes what people read on GitHub and nothing
+else. Winget already has whatever the body said. Version 0.3.1 went to winget
+with no `ReleaseNotes` at all, because the notes were written six minutes after
+komac had run.
+
+That is the reason the body is composed in the workflow rather than typed in
+later, and the reason a file here has to be committed with the release rather
+than added afterwards.
+
+## Writing them
+
+```bash
+python scripts/bump_version.py notes    # scaffolds the file from the commit log
+```
+
+Then edit it and commit it with the release, which `bump_version.py release
+--commit` does for you. Write for someone deciding whether to upgrade.
+
+Skipping this is fine. A release with no file here gets the generated body,
+which is plainer but accurate and on time. The release commands only stop you
+for a file that exists but still has its `TODO` line, or one you wrote and
+forgot to commit before tagging.

--- a/scripts/bump_version.py
+++ b/scripts/bump_version.py
@@ -15,10 +15,24 @@ With -dev suffix workflow:
   2. Prepare release: "X.Y.Z-dev" -> "X.Y.Z" (remove -dev, commit, tag)
   3. Start next cycle: "X.Y.Z" -> "X.Y.Z+1-dev" (bump + add -dev, commit)
 
+Release notes are optional. The Release workflow always composes a body: it uses
+release-notes/vX.Y.Z.md when that file is committed, and otherwise generates one
+from the commit subjects since the last tag. Either way the body exists the
+moment the release is created, which is what matters, because publishing copies
+it into the winget manifest about a minute later and editing the release page
+afterwards never reaches winget.
+
+So write notes when a release deserves them and skip it when it does not:
+  bump_version.py notes    scaffolds release-notes/vX.Y.Z.md from the commit log
+The release commands only stop you for a file that exists but is unfinished, or
+one written but left uncommitted at tag time. See release-notes/README.md.
+
 Best practice (release): CI must pass for the release commit before the Release
 workflow will build. The script walks you through; use --tag-only to create and
 push the tag (no manual git tag commands). Recommended flow:
-  1. bump_version.py release --commit   (commits release version, no tag yet)
+  0. bump_version.py notes              (optional; write release-notes/vX.Y.Z.md)
+  1. bump_version.py release --commit   (commits release version and any notes,
+                                         no tag yet)
   2. git push                           (push to main only)
   3. Wait for CI to pass on that commit
   4. bump_version.py release --tag-only (creates vX.Y.Z from Cargo.toml, pushes tag)
@@ -291,6 +305,11 @@ def commit_version_changes(project_root: Path, version: str, script_name: str, i
         # Only include README.md for releases (badge only updated for releases)
         if is_release:
             files_to_add.append("README.md")
+            # The notes have to be in the release commit: the Release workflow
+            # reads them out of the tagged commit to build the release body.
+            notes_rel = release_notes_relpath(version)
+            if (project_root / notes_rel).exists():
+                files_to_add.append(notes_rel)
         if (project_root / "crates" / "datui-cli" / "Cargo.toml").exists():
             files_to_add.append("crates/datui-cli/Cargo.toml")
         if (project_root / "crates" / "datui-lib" / "Cargo.toml").exists():
@@ -354,6 +373,170 @@ def push_tag(project_root: Path, version: str) -> None:
         raise RuntimeError(f"Git push tag failed: {e}")
 
 
+# Optional hand-written release notes, one file per tag. release.yml prefers
+# this file and falls back to the commit log, so the release body is never empty
+# and never late. That timing is the whole point: publishing runs about a minute
+# after the release is created and komac copies the body into the winget
+# manifest, so notes typed onto the release page afterwards arrive too late.
+# 0.3.1 shipped to winget with no ReleaseNotes that way.
+RELEASE_NOTES_DIR = "release-notes"
+
+# A scaffolded file still carrying this has not been written yet. Shipping that
+# text would be worse than shipping the generated body, so the release commands
+# stop for it.
+NOTES_TODO_SENTINEL = "TODO: write the release notes"
+
+
+def release_notes_relpath(version: str) -> str:
+    """Repo-relative path to the notes for a version (release-notes/v0.3.2.md)."""
+    return f"{RELEASE_NOTES_DIR}/v{version}.md"
+
+
+def release_notes_path(project_root: Path, version: str) -> Path:
+    """Absolute path to the notes for a version."""
+    return project_root / release_notes_relpath(version)
+
+
+def previous_release_tag(project_root: Path) -> str | None:
+    """Most recent vX.Y.Z tag reachable from HEAD, or None on the first release."""
+    try:
+        result = subprocess.run(
+            ["git", "describe", "--tags", "--abbrev=0", "--match", "v*"],
+            cwd=project_root,
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+    except subprocess.CalledProcessError:
+        return None
+    return result.stdout.strip() or None
+
+
+def commit_subjects_since(project_root: Path, since_tag: str | None) -> list[str]:
+    """Commit subjects since a tag, newest first, for scaffolding the notes."""
+    rev_range = f"{since_tag}..HEAD" if since_tag else "HEAD"
+    try:
+        result = subprocess.run(
+            ["git", "log", "--no-merges", "--format=%h %s", rev_range],
+            cwd=project_root,
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+    except subprocess.CalledProcessError:
+        return []
+    return [line for line in result.stdout.splitlines() if line.strip()]
+
+
+def scaffold_release_notes(project_root: Path, version: str) -> Path:
+    """Write a starter notes file for a version. Never overwrites an existing one."""
+    path = release_notes_path(project_root, version)
+    if path.exists():
+        return path
+
+    previous = previous_release_tag(project_root)
+    commits = commit_subjects_since(project_root, previous)
+    repo = "https://github.com/derekwisong/datui"
+
+    lines = [
+        "## What's changed",
+        "",
+        f"{NOTES_TODO_SENTINEL} for v{version}, then delete this line.",
+        "",
+        "<!--",
+        "This file becomes the GitHub release body verbatim, and komac copies it",
+        "into the winget manifest. Write it for someone deciding whether to",
+        "upgrade, not as a commit log. Delete the file to release without it; the",
+        "body is then generated from the commits below.",
+        "",
+    ]
+    if commits:
+        since = previous or "the start of the project"
+        lines.append(f"Commits since {since}, for reference. Delete what you do not use:")
+        lines.extend(f"  {commit}" for commit in commits)
+    else:
+        lines.append("No commits found since the last tag.")
+    lines.extend(["-->", ""])
+    if previous:
+        lines.append(f"**Full changelog**: {repo}/compare/{previous}...v{version}")
+        lines.append("")
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("\n".join(lines), encoding="utf-8")
+    return path
+
+
+def _describe_notes_problems(
+    text: str | None, rel_path: str, location: str, required: bool
+) -> list[str]:
+    """Reasons the given notes content is not fit to ship.
+
+    Absence is fine when the notes are optional: the workflow falls back to the
+    commit log. Content that exists but is unfinished never is.
+    """
+    if text is None:
+        return [f"{rel_path} does not exist {location}"] if required else []
+    if not text.strip():
+        return [f"{rel_path} is empty"]
+    if NOTES_TODO_SENTINEL in text:
+        return [f"{rel_path} still has the scaffolded '{NOTES_TODO_SENTINEL}' line"]
+    return []
+
+
+def check_release_notes_worktree(
+    project_root: Path, version: str, required: bool = False
+) -> list[str]:
+    """Problems with the notes on disk. An empty list means there is nothing to fix."""
+    path = release_notes_path(project_root, version)
+    text = path.read_text(encoding="utf-8") if path.exists() else None
+    return _describe_notes_problems(text, release_notes_relpath(version), "on disk", required)
+
+
+def check_release_notes_committed(project_root: Path, version: str) -> list[str]:
+    """Problems with the notes about to be tagged.
+
+    The workflow reads the file out of the tagged commit, so what is on disk is
+    not what ships. Notes sitting uncommitted at tag time are the trap this
+    catches: the release would silently fall back to the generated body while
+    the good text stays on the author's machine.
+    """
+    rel_path = release_notes_relpath(version)
+    on_disk = release_notes_path(project_root, version).exists()
+    try:
+        result = subprocess.run(
+            ["git", "show", f"HEAD:{rel_path}"],
+            cwd=project_root,
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+    except subprocess.CalledProcessError:
+        if on_disk:
+            return [
+                f"{rel_path} exists but is not committed, so the tag would fall back "
+                f"to the generated body and ignore it"
+            ]
+        return []
+    return _describe_notes_problems(result.stdout, rel_path, "at HEAD", required=False)
+
+
+def report_notes_problems(problems: list[str], version: str) -> None:
+    """Print what is wrong with the notes, and how to move on."""
+    # Keep the two streams in order when the run is piped to a log.
+    sys.stdout.flush()
+    print("Error: the release notes are not ready to ship.", file=sys.stderr)
+    for problem in problems:
+        print(f"  - {problem}", file=sys.stderr)
+    print(file=sys.stderr)
+    print(f"Finish {release_notes_relpath(version)} and commit it, or delete it to", file=sys.stderr)
+    print("let the release generate its body from the commit log instead.", file=sys.stderr)
+    print(file=sys.stderr)
+    print("Whichever you pick, the body has to be right before the tag is pushed:", file=sys.stderr)
+    print("publishing copies it into the winget manifest about a minute later, and", file=sys.stderr)
+    print("editing the release afterwards does not reach winget. See", file=sys.stderr)
+    print("release-notes/README.md.", file=sys.stderr)
+
+
 def main():
     parser = argparse.ArgumentParser(
         description="Bump version number in Cargo.toml and README.md",
@@ -364,6 +547,10 @@ Commands:
   major           Bump major version and add -dev (0.2.11 -> 1.0.0-dev)
   minor           Bump minor version and add -dev (0.2.11 -> 0.3.0-dev)
   patch           Bump patch version and add -dev (0.2.11 -> 0.2.12-dev)
+
+Release notes are optional; the release generates a body from the commit log
+when there is no file. Write them when a release deserves it:
+  python scripts/bump_version.py notes
 
 Best practice (release): Push main first, wait for CI, then run --tag-only.
   python scripts/bump_version.py release --commit
@@ -378,8 +565,9 @@ Start next dev cycle:
     )
     parser.add_argument(
         "command",
-        choices=["release", "major", "minor", "patch"],
-        help="Version operation: 'release' removes -dev, others bump and add -dev",
+        choices=["release", "major", "minor", "patch", "notes"],
+        help="Version operation: 'release' removes -dev, others bump and add -dev; "
+             "'notes' scaffolds the release notes for the upcoming release",
     )
     parser.add_argument(
         "--commit",
@@ -403,6 +591,11 @@ Start next dev cycle:
     # --tag and --tag-only only valid for release
     if (args.tag or args.tag_only) and args.command != "release":
         print("Error: --tag and --tag-only can only be used with 'release' command", file=sys.stderr)
+        sys.exit(1)
+
+    # 'notes' writes one file and changes no version, so the git flags are meaningless
+    if args.command == "notes" and args.commit:
+        print("Error: 'notes' only writes the notes file; commit it with 'release --commit'", file=sys.stderr)
         sys.exit(1)
     
     # --tag-only and --commit/--tag are mutually exclusive
@@ -437,6 +630,28 @@ Start next dev cycle:
     current_version = get_current_version(cargo_toml_path)
     print(f"Current version (from main Cargo.toml): {current_version}")
 
+    # 'notes' only writes the notes file; it touches no version at all.
+    if command == "notes":
+        # Works both before the release commit (X.Y.Z-dev) and after it (X.Y.Z),
+        # so the notes can still be written once the version has been bumped.
+        _, _, _, suffix = parse_version(current_version)
+        release_version = prepare_release(current_version) if suffix == "-dev" else current_version
+        path = release_notes_path(project_root, release_version)
+        existed = path.exists()
+        scaffold_release_notes(project_root, release_version)
+        rel_path = release_notes_relpath(release_version)
+        if existed:
+            print(f"{rel_path} already exists; leaving it alone.")
+        else:
+            print(f"Scaffolded {rel_path} from the commits since the last tag.")
+        print()
+        print("Write it, then commit it with the release:")
+        print(f"  python scripts/{script_name} release --commit")
+        print()
+        print("Skipping it is fine too. Delete the file and the release body will be")
+        print("generated from the commit log instead.")
+        return
+
     # --tag-only: create and push tag for current commit (run after CI passes)
     if is_release and args.tag_only:
         _, _, _, suffix = parse_version(current_version)
@@ -445,6 +660,12 @@ Start next dev cycle:
                 "Error: Current version has -dev suffix. Run 'release --commit' first, push, wait for CI, then run --tag-only.",
                 file=sys.stderr,
             )
+            sys.exit(1)
+        # Last gate before the Release workflow fires. Check the committed file,
+        # not the working tree: the workflow reads it out of the tagged commit.
+        problems = check_release_notes_committed(project_root, current_version)
+        if problems:
+            report_notes_problems(problems, current_version)
             sys.exit(1)
         tag_name = f"v{current_version}"
         try:
@@ -473,6 +694,23 @@ Start next dev cycle:
     
     print(f"New version: {new_version}")
     print()
+
+    # Notes are optional: the Release workflow generates a body from the commit
+    # log when there is no file. A half-written file is the one case worth
+    # stopping for, since that is what would ship. Checked before anything is
+    # modified, so a stopped run leaves the tree clean and can just be re-run.
+    if is_release:
+        problems = check_release_notes_worktree(project_root, new_version, required=False)
+        if problems:
+            report_notes_problems(problems, new_version)
+            sys.exit(1)
+        rel_path = release_notes_relpath(new_version)
+        if (project_root / rel_path).exists():
+            print(f"Release notes ready: {rel_path}")
+        else:
+            print(f"No {rel_path}; the release body will be generated from the commit log.")
+            print(f"  To write them yourself: python scripts/{script_name} notes")
+        print()
 
     # All Cargo.toml package versions to keep in sync (main is source of truth; others set to new_version)
     cargo_toml_files = [

--- a/tests/release_notes_test.rs
+++ b/tests/release_notes_test.rs
@@ -1,0 +1,112 @@
+//! Release notes, and the wiring that gets them onto the GitHub release.
+//!
+//! The release body is not cosmetic. `publish-packages.yml` runs about a minute
+//! after the release is created, and komac copies whatever the body says into
+//! the winget manifest as `ReleaseNotes`. An empty body there produces a winget
+//! PR that is silently missing metadata the previous version had, which winget
+//! flags only after a moderator is already looking at it. That is how 0.3.1
+//! shipped: the notes were written on the release page six minutes too late.
+//!
+//! So the workflow composes the body itself: hand-written notes from
+//! `release-notes/<tag>.md` when they exist, and the commit log when they do
+//! not. Notes are optional; a body is not. These tests guard that the composing
+//! step is still wired up, and that a notes file which does exist is finished.
+//!
+//! CI has to pass on the release commit before the tag is pushed, so these run
+//! at exactly the moment they can still prevent a bad release.
+
+const RELEASE_WORKFLOW: &str = ".github/workflows/release.yml";
+const PUBLISH_WORKFLOW: &str = ".github/workflows/publish-packages.yml";
+const NOTES_TODO_SENTINEL: &str = "TODO: write the release notes";
+
+fn read(path: &str) -> String {
+    std::fs::read_to_string(path).unwrap_or_else(|e| panic!("{path} should exist: {e}"))
+}
+
+/// The version in Cargo.toml, and whether this is a release commit.
+///
+/// Between releases the version carries a `-dev` suffix and there is nothing to
+/// check yet; the notes are written when `bump_version.py release` drops it.
+fn release_version() -> Option<&'static str> {
+    let version = env!("CARGO_PKG_VERSION");
+    if version.ends_with("-dev") {
+        None
+    } else {
+        Some(version)
+    }
+}
+
+#[test]
+fn test_notes_for_this_release_are_finished() {
+    // Notes are optional, so absence is fine. A file that exists is what ships,
+    // and a half-written one would ship instead of the generated body.
+    let Some(version) = release_version() else {
+        return;
+    };
+    let path = format!("release-notes/v{version}.md");
+    let Ok(notes) = std::fs::read_to_string(&path) else {
+        return;
+    };
+
+    assert!(
+        !notes.trim().is_empty(),
+        "{path} is empty; delete it to let the release generate a body from the commit log"
+    );
+    assert!(
+        !notes.contains(NOTES_TODO_SENTINEL),
+        "{path} still has the scaffolded '{NOTES_TODO_SENTINEL}' line; finish it or delete it"
+    );
+}
+
+#[test]
+fn test_release_workflow_composes_a_body() {
+    // Without this the release is created with an empty body, and the publish
+    // pipeline reads that empty body before anyone can type into it.
+    let workflow = read(RELEASE_WORKFLOW);
+    assert!(
+        workflow.contains("name: Compose release body"),
+        "{RELEASE_WORKFLOW} should compose the release body before creating the release"
+    );
+    assert!(
+        workflow.contains("body_path: ${{ steps.release_body.outputs.path }}"),
+        "{RELEASE_WORKFLOW} should hand the composed body to the release as body_path; \
+         without it the release is created empty and winget copies the emptiness"
+    );
+}
+
+#[test]
+fn test_winget_publish_refuses_an_empty_release_body() {
+    // Belt and braces for the case where a tag is pushed by hand: better to fail
+    // the job than to open a winget PR that is missing metadata.
+    let workflow = read(PUBLISH_WORKFLOW);
+    assert!(
+        workflow.contains("Check the release body is populated (preflight)"),
+        "{PUBLISH_WORKFLOW} should preflight the release body before running komac"
+    );
+}
+
+#[test]
+fn test_notes_are_named_for_their_tag() {
+    // release.yml interpolates the tag straight into the filename, so a file
+    // named anything else is invisible to the release no matter what it says.
+    let dir = std::fs::read_dir("release-notes").expect("release-notes/ should exist");
+    for entry in dir {
+        let name = entry.expect("readable entry").file_name();
+        let name = name.to_string_lossy().to_string();
+        if name == "README.md" {
+            continue;
+        }
+        assert!(
+            name.starts_with('v') && name.ends_with(".md"),
+            "release-notes/{name} should be named v<version>.md to match its tag"
+        );
+        let version = &name[1..name.len() - 3];
+        assert!(
+            version.split('.').count() == 3
+                && version
+                    .split('.')
+                    .all(|part| part.chars().all(|c| c.is_ascii_digit())),
+            "release-notes/{name} should be named for an X.Y.Z version"
+        );
+    }
+}


### PR DESCRIPTION
## The problem

`publish-packages.yml` starts about a minute after a release is created, and komac copies the GitHub release body into the winget manifest as `ReleaseNotes`. The release step passed no `body` or `body_path`, so releases were created empty and the notes were written on the release page afterwards.

For 0.3.1 that gap was six minutes, and komac lost the race:

| Event | Time (UTC) |
| --- | --- |
| Release created | 13:32:36 |
| Komac generated the manifest | 13:33:51 |
| Release body written | 13:39:19 |

[microsoft/winget-pkgs#431943](https://github.com/microsoft/winget-pkgs/pull/431943) went out missing `ReleaseNotes` and `ReleaseNotesUrl`, and picked up the `Manifest-Metadata-Consistency` label. 0.3.0 only escaped by accident: its winget job was re-run five hours late after the fork sync failure, by which point the notes existed.

Editing the release afterwards cannot fix this. It changes what people read on GitHub and nothing else, because winget already has whatever the body said.

## The fix

`release.yml` composes the body itself, before creating the release:

- Hand-written notes at `release-notes/<tag>.md` are used when committed.
- Otherwise the body is generated from the commit subjects since the previous tag, minus `bump_version.py`'s own `Release` and `Bump version to` commits.

Either way the body exists the instant the release does. Notes stay optional, so this costs no extra commit and no extra CI cycle.

## Everything else

- `bump_version.py notes` scaffolds a notes file from the commit log when a release deserves prose.
- The release commands stop for only two things: a notes file that still has its `TODO` line, and one written but left uncommitted at tag time, which would silently lose the text to the generated body.
- The winget job refuses to run komac against an empty release body.
- `tests/release_notes_test.rs` holds the wiring in place. It runs on the release commit, before the tag is pushed, which is the last moment any of this can help.

## Verification

The compose step was run locally against the real `v0.3.1`, `v0.2.34` and `v0.2.0` tags, covering the hand-written path, the generated path, and the first-release case with no previous tag. Generated body for v0.3.1:

```
## What's changed

- Record a home-screen demo, and stop dropping what the footer said

**Full changelog**: https://github.com/derekwisong/datui/compare/v0.3.0...v0.3.1
```

The bump script gates were exercised for every case: missing file, `TODO` stub, empty file, finished file, and written-but-uncommitted. The new test passes, and fails when a release version has an unfinished notes file.

The 0.3.1 winget manifest was fixed separately by pushing the two missing properties to that PR branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KYovFFSm6WaquKvGxo5PUd
