### PR TITLE
Add a security policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,9 @@ This project is licensed under the MIT License - see the [LICENSE](LICENSE) file
 
 > If you encounter any issues or have feature requests, please
 > [open an issue on  GitHub](https://github.com/derekwisong/datui/issues).
+>
+> Found a security problem? Please report it privately instead. See
+> [SECURITY.md](SECURITY.md).
 
 [docs]: https://derekwisong.github.io/datui/
 [config-guide]: https://derekwisong.github.io/datui/latest/user-guide/configuration.html

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,129 @@
+# Security Policy
+
+## Reporting a vulnerability
+
+Please report security issues privately, through GitHub's private vulnerability
+reporting:
+
+**[Report a vulnerability](https://github.com/derekwisong/datui/security/advisories/new)**
+
+That opens a private draft advisory visible only to you and the maintainer. It
+is the right channel even if you are not sure whether what you found is a
+security issue.
+
+Please do not open a public issue for a suspected vulnerability. A public issue
+tells everyone about the problem before there is a fix, including people who
+would rather use it than report it.
+
+Helpful things to include, as far as you have them:
+
+- What an attacker gains, in one sentence.
+- The steps to reproduce, and the datui version and platform.
+- A sample file, if a particular input triggers it. A minimal one is easier to
+  work with than a real dataset.
+
+### What to expect
+
+| | |
+|---|---|
+| Acknowledgement | Within 7 days |
+| Assessment and fix timeline | After triage, since it depends on severity |
+| Credit | Named in the advisory, unless you would rather not be |
+
+datui is maintained by one person. A fix timeline comes after the report has
+been read and reproduced rather than being promised up front. You will get a
+straight answer about severity and timing rather than an optimistic one.
+
+Please keep the details private until a fix is released, or for 90 days,
+whichever comes first. If a fix is taking longer than that, say so and we will
+agree on what happens next.
+
+## Supported versions
+
+Only the most recent release receives security fixes. A fix ships as a new
+release across every channel datui publishes to: crates.io, PyPI, Homebrew,
+the AUR, WinGet, and the APT repository.
+
+datui is pre-1.0 and moving quickly. This policy will tighten at 1.0.
+
+## What datui defends against
+
+The short version: **datui trusts the person running it, and does not trust the
+data it opens.**
+
+That distinction is what decides whether something is a vulnerability.
+
+### In scope
+
+Anything that lets a **file or URL** do something the person who opened it did
+not ask for. datui reads Parquet, CSV, JSON, Avro, Arrow, ORC and Excel, over
+local paths, S3, GCS and HTTP, and none of that content is trusted. Reports are
+wanted for:
+
+- Memory corruption, or any crash that looks exploitable, from a malformed file.
+- Escaping the terminal: a file whose contents, column names or filename emit
+  escape sequences that change the terminal's state, write to the clipboard, or
+  spoof the interface.
+- Reading or writing files outside what was opened, including through export
+  paths, template files, cache and temporary files.
+- Making network requests that were not asked for, or sending data somewhere
+  the user did not name.
+- Leaking credentials. In particular, S3 keys appearing in error messages,
+  debug output, cache files, or saved templates.
+- Anything in the release and packaging pipeline that would let a third party
+  influence a published artifact.
+
+### Out of scope
+
+**A serialized query plan passed to the Python API is trusted input.**
+`datui.view()` accepts a Polars `LazyFrame`, which reaches the extension as a
+serialized plan. A plan is closer to a program than to data: it can name
+arbitrary file paths to read. Building something that feeds attacker-supplied
+plan bytes to `datui.view()` is a bug in that program, in the same way that
+passing attacker input to `eval()` is.
+
+For what it is worth, this build cannot execute arbitrary code from a plan.
+Polars' Python user-defined-function support is not compiled in, so the plan
+nodes that carry pickled Python callables cannot be deserialized. That is a
+property of the current build configuration, not a security boundary, and it is
+not something to rely on.
+
+Also out of scope:
+
+- **Denial of service against yourself.** A file that makes datui hang or
+  exhaust memory is a bug worth reporting as a normal issue, but opening a
+  hostile file in a local viewer you launched is not a privilege boundary.
+- **Vulnerabilities in dependencies** with no path to reach them from datui.
+  Advisories that are reachable are tracked in `deny.toml` with the reasoning.
+- **Anything requiring an attacker who can already write to your home
+  directory**, since at that point the config file is the least of it.
+- Missing hardening flags, or scanner output, without a demonstrated impact.
+
+## How datui is checked
+
+Every pull request runs `cargo-deny` against the RustSec advisory database and
+`zizmor` against the workflow files. OpenSSF Scorecard reports supply-chain
+posture on a schedule. See
+[Security Checks](https://derekwisong.github.io/datui/latest/for-developers/security-checks.html)
+for what those cover and how to run them locally.
+
+## Verifying what you install
+
+Being straight about where this currently stands.
+
+The APT repository is signed, and its GPG key is fetched over HTTPS during
+setup. The AUR package carries checksums in its `PKGBUILD`.
+
+Release tarballs, zips and wheels are **not** currently published with a
+checksum file or a signature, which means the one-line installer and a manual
+download from the releases page both trust HTTPS and GitHub alone. Publishing
+signed checksums, and verifying them in the installer, is known work that has
+not been done yet.
+
+If you want the strongest assurance available today, build from source:
+
+```bash
+git clone https://github.com/derekwisong/datui.git
+cd datui
+cargo build --release --locked
+```

--- a/docs/for-developers/security-checks.md
+++ b/docs/for-developers/security-checks.md
@@ -1,5 +1,9 @@
 # Security Checks
 
+> Reporting a vulnerability, rather than running the checks? See
+> [SECURITY.md](https://github.com/derekwisong/datui/blob/main/SECURITY.md),
+> which also states what datui does and does not defend against.
+
 Datui runs two automated security checks alongside the usual format and clippy
 gates. Both are in the `Security` workflow, and both can be run locally.
 


### PR DESCRIPTION
Adds `SECURITY.md`, so that someone who finds a vulnerability has a private place to send it. Today their only options are a public issue or silence, and the first one discloses the problem to everyone before a fix exists.

## The policy

| | |
|---|---|
| Channel | GitHub private vulnerability reporting |
| Acknowledgement | 7 days |
| Fix timeline | After triage, since it depends on severity |
| Supported | Latest release only |
| Embargo | Until a fix ships, or 90 days |

Seven days to acknowledge, with no fix deadline promised up front, is what one maintainer can keep through a busy fortnight. A missed deadline costs more credibility than a modest one.

## Scope is most of the file

Scope is what decides whether a report is a vulnerability or a normal bug, and writing it down beforehand is what lets you answer a report calmly instead of scrambling.

The line drawn is: **datui trusts the person running it, and does not trust the data it opens.** In scope is anything a file or URL can do that the user did not ask for. Memory corruption from a malformed file, terminal escape sequences reaching the terminal, reads or writes outside what was opened, unrequested network traffic, leaked S3 credentials, and anything in the release pipeline that lets a third party influence a published artifact.

Out of scope, and stated explicitly:

- **A serialized query plan passed to `datui.view()` is trusted input.** A plan is closer to a program than to data and can name arbitrary paths to read, so feeding attacker-supplied plan bytes to the Python API is a bug in the calling program, the same way passing attacker input to `eval()` is.
- Denial of service against your own session, which is a normal bug.
- Dependency advisories with no reachable path from datui. Reachable ones are tracked in `deny.toml` with the reasoning.
- Anything needing an attacker who can already write to your home directory.

## One thing worth knowing

While writing the scope section I checked what a hostile plan can actually reach, rather than assuming the worst case. **This build cannot execute arbitrary code from a plan.** Polars' Python user-defined-function support is not compiled in, so the plan nodes that carry pickled Python callables cannot be deserialized at all. Verified by confirming `polars-plan` has no `pyo3` dependency in the lockfile.

That is written up in `SECURITY.md` as a property of the current build rather than as a security boundary, because a feature flag could change it and nobody should build on top of it.

## Being straight about installs

The section on verifying an install says plainly that release tarballs, zips and wheels ship with **no checksum file and no signature** today, so the one-line installer trusts HTTPS and GitHub alone. The APT repository is signed and the AUR `PKGBUILD` carries checksums; the rest is a known gap. Anyone wanting better assurance is pointed at building from source.

Claiming verification that does not exist would be worse than saying nothing.

## Needs doing on GitHub after merge

**Private vulnerability reporting has to be switched on** under Settings, Security, or the link in this file leads nowhere. That is a repository setting and cannot be done from a pull request.

Worth checking Dependabot is enabled at the same time, since the config file merged earlier does not switch it on by itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T3dG16ZsDzbMnN2yJtdYw4
