### PR TITLE
Upgrade calamine to 0.36 and cover the Excel reader with tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -148,15 +148,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "arbitrary"
-version = "1.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
-dependencies = [
- "derive_arbitrary",
-]
-
-[[package]]
 name = "argminmax"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -460,6 +451,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "atoi_simd"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3cdb3708a128e559a30fb830e8a77a5022ee6902806925c216658652b452a44"
+dependencies = [
+ "debug_unsafe",
+ "rustversion",
+]
+
+[[package]]
 name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -663,18 +664,18 @@ dependencies = [
 
 [[package]]
 name = "calamine"
-version = "0.32.0"
+version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41bdeb83af82cd9cb686a19ed7efc2f50a21c262610f51ce945a8528860725ce"
+checksum = "5fa68281b1a76b54a62156474adb06bb380a67e07dd60656e3217152b42183f3"
 dependencies = [
- "atoi_simd",
+ "atoi_simd 0.18.1",
  "byteorder",
  "chrono",
  "codepage",
  "encoding_rs",
  "fast-float2",
  "log",
- "quick-xml",
+ "quick-xml 0.41.0",
  "serde",
  "zip",
 ]
@@ -1344,17 +1345,6 @@ name = "deranged"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
-
-[[package]]
-name = "derive_arbitrary"
-version = "1.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e567bd82dcff979e4b03460c307b3cdc9e96fde3d73bed1496d2bc75d9dd62a"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.119",
-]
 
 [[package]]
 name = "derive_more"
@@ -2857,7 +2847,7 @@ dependencies = [
  "md-5",
  "parking_lot",
  "percent-encoding",
- "quick-xml",
+ "quick-xml 0.38.4",
  "rand 0.9.5",
  "reqwest",
  "ring",
@@ -3123,7 +3113,7 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33d3fe43f8702cf7899ff3d516c2e5f7dc84ee6f6a3007e1a831a0ff87940704"
 dependencies = [
- "atoi_simd",
+ "atoi_simd 0.16.1",
  "avro-schema",
  "bitflags 2.13.1",
  "bytemuck",
@@ -3166,7 +3156,7 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d29cc7497378dee3a002f117e0b4e16b7cbe6c8ed3da16a0229c89294af7c3bf"
 dependencies = [
- "atoi_simd",
+ "atoi_simd 0.16.1",
  "bytemuck",
  "chrono",
  "either",
@@ -3284,7 +3274,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be3714acdff87170141880a07f5d9233490d3bd5531c41898f6969d440feee11"
 dependencies = [
  "async-trait",
- "atoi_simd",
+ "atoi_simd 0.16.1",
  "blake3",
  "bytes",
  "chrono",
@@ -3601,7 +3591,7 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ddce7a9f81d5f47d981bcee4a8db004f9596bb51f0f4d9d93667a1a00d88166c"
 dependencies = [
- "atoi_simd",
+ "atoi_simd 0.16.1",
  "bytemuck",
  "chrono",
  "chrono-tz",
@@ -3723,9 +3713,18 @@ version = "0.38.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b66c2058c55a409d601666cffe35f04333cf1013010882cec174a7467cd4e21c"
 dependencies = [
- "encoding_rs",
  "memchr",
  "serde",
+]
+
+[[package]]
+name = "quick-xml"
+version = "0.41.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e660451e55124f798a69a5af3f49ccfbefbd41910eefd25caf2393e1f3473ec1"
+dependencies = [
+ "encoding_rs",
+ "memchr",
 ]
 
 [[package]]
@@ -4999,6 +4998,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5283634e518fe9e82c7b20520bb4bc209009fd16c82077c802f8111ecbb0117a"
 
 [[package]]
+name = "typed-path"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e28f89b80c87b8fb0cf04ab448d5dd0dd0ade2f8891bae878de66a75a28600e"
+
+[[package]]
 name = "typenum"
 version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5705,15 +5710,15 @@ dependencies = [
 
 [[package]]
 name = "zip"
-version = "4.6.1"
+version = "8.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "caa8cd6af31c3b31c6631b8f483848b91589021b28fffe50adada48d4f4d2ed1"
+checksum = "2d04a6b5381502aa6087c94c669499eb1602eb9c5e8198e534de571f7154809b"
 dependencies = [
- "arbitrary",
  "crc32fast",
  "flate2",
  "indexmap",
  "memchr",
+ "typed-path",
  "zopfli",
 ]
 

--- a/crates/datui-lib/Cargo.toml
+++ b/crates/datui-lib/Cargo.toml
@@ -41,7 +41,7 @@ xz2 = "0.1"
 flate2 = "1.0"
 zstd = "0.13"
 plotters = "0.3"
-calamine = { version = "0.32", features = ["chrono"] }
+calamine = { version = "0.36", features = ["chrono"] }
 orc-rust = "0.7"
 arrow = "57"
 tempfile = "3.14"

--- a/deny.toml
+++ b/deny.toml
@@ -21,17 +21,28 @@ version = 2
 # fixed today and what event should clear it. Review this list whenever
 # Dependabot lands a dependency bump.
 ignore = [
-    # --- Reachable from untrusted input: fix these first ---
-
-    # quick-xml, both reachable through calamine when datui opens an .xlsx file,
-    # which is attacker-controlled data by definition. Both are denial of
-    # service (quadratic parse, unbounded namespace allocation), not memory
-    # corruption: the process hangs or is OOM-killed. Patched in quick-xml
-    # >= 0.41, but calamine 0.32 requires 0.38.
-    # Clears when: datui upgrades calamine 0.32 -> 0.36, which is a breaking API
-    # change and needs its own pull request.
-    { id = "RUSTSEC-2026-0194", reason = "quick-xml DoS via calamine (.xlsx); blocked on the calamine 0.36 upgrade" },
-    { id = "RUSTSEC-2026-0195", reason = "quick-xml DoS via calamine (.xlsx); blocked on the calamine 0.36 upgrade" },
+    # quick-xml 0.38, two denial-of-service bugs: quadratic parsing of duplicate
+    # attribute names, and unbounded namespace allocation. Patched in 0.41.
+    #
+    # These were the highest-priority entries in this file while calamine held
+    # quick-xml at 0.38, because that put them on the .xlsx path, where the
+    # input is whatever spreadsheet the user opened. calamine 0.36 moved to
+    # quick-xml 0.41 and closed that path.
+    #
+    # What is left is a second copy of 0.38 pulled in by object_store, which
+    # uses it to parse the XML that S3 and GCS return. Reaching it means
+    # pointing datui at an object-store endpoint that answers with hostile XML,
+    # so it needs a malicious or compromised endpoint the user chose, rather
+    # than a file they opened. Worst case is still a hang or an OOM kill, not
+    # memory corruption.
+    #
+    # No upgrade is available: polars 0.52 pins object_store 0.12, so raising
+    # datui's own object_store dependency would add a second copy and leave the
+    # vulnerable one in the tree behind polars.
+    # Clears when: polars bumps object_store to a release built on quick-xml
+    # 0.41 or later.
+    { id = "RUSTSEC-2026-0194", reason = "quick-xml DoS; xlsx path fixed by calamine 0.36, remaining copy is object_store S3/GCS XML, pinned by polars" },
+    { id = "RUSTSEC-2026-0195", reason = "quick-xml DoS; xlsx path fixed by calamine 0.36, remaining copy is object_store S3/GCS XML, pinned by polars" },
 
     # pyo3 0.26, in crates/datui-pyo3. Both are memory-safety bugs, patched in
     # pyo3 0.29. Neither is reachable from this crate: the out-of-bounds read is

--- a/tests/excel_test.rs
+++ b/tests/excel_test.rs
@@ -1,0 +1,176 @@
+//! Tests for reading Excel workbooks.
+//!
+//! The Excel path goes through calamine rather than Polars, and it was the only
+//! input format with no coverage at all. That gap surfaced during a calamine
+//! upgrade: the whole suite passed without once opening a spreadsheet, so it
+//! could not say whether the new version still read one correctly.
+//!
+//! These assert on actual cell values, not just that a load returned something,
+//! because the failure mode of an Excel reader upgrade is silently wrong data:
+//! shifted columns, dates read as serial numbers, booleans read as integers.
+
+use datui::{App, AppEvent, OpenOptions};
+use polars::prelude::*;
+use std::path::PathBuf;
+use std::sync::mpsc;
+
+mod common;
+
+/// Pumps the load event chain until the file is open, including background
+/// task results delivered over the channel.
+fn pump_open_until_loaded(
+    app: &mut App,
+    rx: &std::sync::mpsc::Receiver<AppEvent>,
+    paths: Vec<PathBuf>,
+    options: OpenOptions,
+) {
+    let mut next: Option<AppEvent> = Some(AppEvent::Open(paths, options));
+    loop {
+        if let Some(ev) = next.take() {
+            if matches!(ev, AppEvent::Crash(_)) {
+                app.event(&ev);
+                return;
+            }
+            next = app.event(&ev);
+        } else {
+            match rx.recv_timeout(std::time::Duration::from_millis(5000)) {
+                Ok(ev) => next = Some(ev),
+                Err(_) => return,
+            }
+        }
+    }
+}
+
+fn open_excel(name: &str, options: OpenOptions) -> DataFrame {
+    common::ensure_sample_data();
+    let (tx, rx) = mpsc::channel();
+    let mut app = App::new(tx, common::test_runtime());
+    let path = PathBuf::from("tests/sample-data").join(name);
+    assert!(path.exists(), "missing fixture: {}", path.display());
+
+    pump_open_until_loaded(&mut app, &rx, vec![path], options);
+
+    let datatable = app
+        .data_table_state
+        .as_ref()
+        .unwrap_or_else(|| panic!("{} did not load", name));
+    datatable.lf.clone().collect().expect("collect")
+}
+
+#[test]
+fn reads_headers_and_row_count() {
+    let df = open_excel("people.xlsx", OpenOptions::default());
+
+    assert_eq!(df.height(), 1000, "people.xlsx has 1000 data rows");
+    assert_eq!(
+        df.get_column_names_str(),
+        [
+            "id",
+            "first_name",
+            "last_name",
+            "age",
+            "city",
+            "state",
+            "department",
+            "job_title",
+            "salary",
+            "start_date",
+            "active",
+        ],
+        "the first sheet row is the header, not data"
+    );
+}
+
+#[test]
+fn reads_cell_values_from_the_first_row() {
+    let df = open_excel("people.xlsx", OpenOptions::default());
+
+    // Guards against an off-by-one that treats the header as data, and against
+    // columns being shifted relative to their names.
+    let first_str = |col: &str| {
+        df.column(col)
+            .unwrap_or_else(|_| panic!("no column {}", col))
+            .get(0)
+            .unwrap()
+            .to_string()
+            .trim_matches('"')
+            .to_string()
+    };
+
+    assert_eq!(first_str("first_name"), "Person1");
+    assert_eq!(first_str("last_name"), "Lastname1");
+    assert_eq!(first_str("city"), "Bristol");
+    assert_eq!(first_str("state"), "MI");
+    assert_eq!(first_str("job_title"), "Junior");
+}
+
+#[test]
+fn reads_numeric_columns_as_numbers() {
+    let df = open_excel("people.xlsx", OpenOptions::default());
+
+    // Not strings. A regression here shows up as sorting and charting silently
+    // treating salaries as text.
+    for col in ["id", "age", "salary"] {
+        let dtype = df.column(col).unwrap().dtype();
+        assert!(
+            dtype.is_primitive_numeric(),
+            "{} should be numeric, got {:?}",
+            col,
+            dtype
+        );
+    }
+
+    let id = df.column("id").unwrap();
+    assert_eq!(id.get(0).unwrap().to_string(), "1");
+    assert_eq!(id.get(999).unwrap().to_string(), "1000");
+}
+
+#[test]
+fn preserves_empty_cells_as_nulls() {
+    let df = open_excel("people.xlsx", OpenOptions::default());
+
+    // The department column has gaps in the fixture. An empty cell must stay
+    // null rather than becoming an empty string or a zero.
+    let department = df.column("department").unwrap();
+    assert!(
+        department.null_count() > 0,
+        "expected empty department cells to read as null"
+    );
+    assert!(
+        department.null_count() < df.height(),
+        "department should not be entirely null"
+    );
+}
+
+#[test]
+fn reads_other_workbooks() {
+    // Breadth over depth: these have different shapes and column types, so a
+    // reader change that only breaks one layout still gets caught.
+    for name in ["sales.xlsx", "mixed_types.xlsx", "single_row.xlsx"] {
+        let df = open_excel(name, OpenOptions::default());
+        assert!(df.width() > 0, "{} produced no columns", name);
+        assert!(df.height() > 0, "{} produced no rows", name);
+    }
+}
+
+#[test]
+fn selects_a_sheet_by_index_and_by_name() {
+    let indexed = open_excel(
+        "people.xlsx",
+        OpenOptions {
+            excel_sheet: Some("0".to_string()),
+            ..Default::default()
+        },
+    );
+    let named = open_excel(
+        "people.xlsx",
+        OpenOptions {
+            excel_sheet: Some("Sheet".to_string()),
+            ..Default::default()
+        },
+    );
+
+    assert_eq!(indexed.height(), named.height());
+    assert_eq!(indexed.width(), named.width());
+    assert_eq!(indexed.height(), 1000);
+}


### PR DESCRIPTION
calamine 0.32 held quick-xml at 0.38, which carries two denial-of-service advisories: quadratic parsing of duplicate attribute names (RUSTSEC-2026-0194) and unbounded namespace allocation (RUSTSEC-2026-0195). Both were reachable from any `.xlsx` datui opened, which is untrusted input by definition. calamine 0.36 moves to quick-xml 0.41, where both are fixed.

## The upgrade itself was free

No source changes. datui touches calamine through one file, and none of the APIs it uses changed.

## Which is exactly the problem

The full suite passed against 0.36 on the first try. It would have passed just as happily against a reader that returned garbage, because **nothing in those 563 tests opened a spreadsheet**. Excel was the only input format with no coverage at all, and it is the one format whose reader is not Polars.

An Excel reader upgrade does not fail by crashing. It fails by silently returning wrong data: a header row read as data, columns shifted by one, dates arriving as serial numbers, empty cells becoming empty strings. Every one of those passes a test that only checks the load succeeded.

So this adds `tests/excel_test.rs`, asserting on actual cell values:

| Test | Guards against |
|---|---|
| `reads_headers_and_row_count` | Header row treated as data |
| `reads_cell_values_from_the_first_row` | Columns shifted relative to their names |
| `reads_numeric_columns_as_numbers` | Salaries silently becoming text |
| `preserves_empty_cells_as_nulls` | Empty cells becoming `""` or `0` |
| `reads_other_workbooks` | A change that only breaks one layout |
| `selects_a_sheet_by_index_and_by_name` | Sheet selection regressions |

## Evidence the upgrade is safe

Tests written after an upgrade tend to encode whatever the new version does. To rule that out, I ran the same six tests against calamine **0.32** as well.

All six pass on both versions. The upgrade preserves exactly what the reader produced before.

## What stays in deny.toml

The two quick-xml entries remain, with corrected reasoning rather than deletion. A second copy of quick-xml 0.38 is still in the tree through `object_store`, which uses it to parse the XML that S3 and GCS return.

The reachability is now much narrower: it needs an object-store endpoint answering with hostile XML, a remote the user chose, rather than a file they opened. And no upgrade is available. polars 0.52 pins `object_store` 0.12, so raising datui's own dependency would add a second copy and leave the vulnerable one in the tree behind polars. The entry says it clears when polars bumps object_store.

## Verification

- 6 new Excel tests pass on calamine 0.36 **and** on 0.32.
- Existing 563 tests still pass.
- `cargo deny check` clean across advisories, bans, licenses and sources.
- clippy with `-D warnings` and `cargo fmt --check` both green.

`zip` also moves 4.6 to 8.6 as a transitive dependency of calamine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T3dG16ZsDzbMnN2yJtdYw4
