### PR TITLE
Stop hostile data from sending commands to the terminal

### DIFF
--- a/crates/datui-lib/src/chart_export.rs
+++ b/crates/datui-lib/src/chart_export.rs
@@ -1077,4 +1077,107 @@ mod tests {
         assert!(content.contains("setrgbcolor"), "series color");
         assert!(content.contains("lineto"), "line series");
     }
+
+    /// Walks a PostScript line and returns the text that sits *outside* string
+    /// literals, which is the part a interpreter executes as code.
+    ///
+    /// Deliberately a real scanner rather than a substring search: the whole
+    /// question is whether a `)` in the data terminates a literal early, and
+    /// only tracking `\` escaping answers that.
+    fn code_outside_strings(line: &str) -> String {
+        let mut out = String::new();
+        let mut chars = line.chars();
+        let mut in_string = false;
+        while let Some(c) = chars.next() {
+            match c {
+                // A backslash escapes the next character, inside a string or not.
+                '\\' => {
+                    chars.next();
+                }
+                '(' if !in_string => in_string = true,
+                ')' if in_string => in_string = false,
+                _ if !in_string => out.push(c),
+                _ => {}
+            }
+        }
+        out
+    }
+
+    /// Chart labels come from column names and cell values, so they are
+    /// untrusted. PostScript is a programming language, and an exported chart
+    /// gets opened by other people in a viewer, so a label that escapes its
+    /// string literal becomes code running on someone else's machine.
+    ///
+    /// `ps_escape` handles this today. This test exists so that a future `show`
+    /// call added without it fails here rather than shipping.
+    #[test]
+    fn chart_labels_cannot_escape_postscript_string_literals() {
+        // Each payload closes the literal and leaves the marker as a bare
+        // token, which is where an interpreter would read it as code. The
+        // marker deliberately sits *outside* any parentheses: text inside a
+        // literal is inert no matter what surrounds it, so a payload shaped
+        // like `) (INJECTED) show (` would pass this test while still being a
+        // real injection.
+        let payloads = [
+            ") INJECTED 0 0 moveto (",
+            "\\) INJECTED (",
+            "a) INJECTED (b",
+            "trailing backslash \\",
+            "unbalanced ( open",
+            "unbalanced ) close",
+        ];
+
+        for payload in payloads {
+            let series = vec![ChartExportSeries {
+                name: payload.to_string(),
+                points: vec![(0.0, 1.0), (1.0, 2.0)],
+            }];
+            let bounds = ChartExportBounds {
+                x_min: 0.0,
+                x_max: 2.0,
+                y_min: 0.0,
+                y_max: 2.5,
+                x_label: payload.to_string(),
+                y_label: payload.to_string(),
+                x_axis_kind: XAxisTemporalKind::Numeric,
+                log_scale: false,
+                chart_title: Some(payload.to_string()),
+            };
+
+            let dir = tempfile::tempdir().expect("temp dir");
+            let path = dir.path().join("chart.eps");
+            write_chart_eps(&path, &series, ChartType::Line, &bounds).expect("write_chart_eps");
+
+            let mut content = String::new();
+            std::fs::File::open(&path)
+                .expect("open")
+                .read_to_string(&mut content)
+                .expect("read");
+
+            for (i, line) in content.lines().enumerate() {
+                // DSC comments are not executed, and carry no data anyway.
+                if line.starts_with('%') {
+                    continue;
+                }
+                let code = code_outside_strings(line);
+                assert!(
+                    !code.contains("INJECTED"),
+                    "payload {:?} escaped its string literal on line {}: {:?}",
+                    payload,
+                    i + 1,
+                    line
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn ps_escape_neutralises_literal_delimiters() {
+        // Backslash must be escaped first, or escaping the parens would
+        // introduce backslashes that then get doubled and stop escaping.
+        assert_eq!(ps_escape("a(b)c"), "a\\(b\\)c");
+        assert_eq!(ps_escape("back\\slash"), "back\\\\slash");
+        assert_eq!(ps_escape("\\)"), "\\\\\\)");
+        assert_eq!(ps_escape("plain"), "plain");
+    }
 }

--- a/crates/datui-lib/src/lib.rs
+++ b/crates/datui-lib/src/lib.rs
@@ -51,6 +51,7 @@ pub mod numfmt;
 pub mod pivot_melt_modal;
 mod query;
 mod render;
+pub mod sanitize;
 pub mod search;
 pub mod sort_filter_modal;
 pub mod sort_modal;
@@ -9768,6 +9769,19 @@ impl Widget for &mut App {
         if let Some(debug_area) = app_layout.debug {
             self.debug.render(debug_area, buf);
         }
+
+        // Last line of defence, and deliberately the last statement here.
+        //
+        // Everything above draws untrusted text: cell values, column names,
+        // filenames, parser messages. ratatui strips control characters in
+        // `Buffer::set_stringn` but not in `Span`/`Line` rendering, which is
+        // what these widgets use, and the crossterm backend then prints each
+        // cell symbol unfiltered. Without this sweep a cell containing
+        // `\x1b]52;c;...\x07` writes to the user's clipboard.
+        //
+        // Doing it here rather than at each of the ~200 `Span` construction
+        // sites means a new widget cannot forget to. See `crate::sanitize`.
+        crate::sanitize::sanitize_buffer(buf);
     }
 }
 

--- a/crates/datui-lib/src/sanitize.rs
+++ b/crates/datui-lib/src/sanitize.rs
@@ -1,0 +1,132 @@
+//! Keeping untrusted text from becoming terminal commands.
+//!
+//! datui displays text it did not write: cell values, column names, filenames,
+//! and parser error messages all originate in whatever file the user opened.
+//! A terminal does not distinguish text from commands, so a cell containing
+//! `\x1b]52;c;...\x07` is a clipboard write, and one containing `\x1b[2J` wipes
+//! the screen. That is the standard vulnerability class for any program that
+//! renders foreign text.
+//!
+//! ratatui defends against this in [`Buffer::set_stringn`], which drops
+//! graphemes containing control characters. It does **not** defend against it
+//! in `Span` and `Line` rendering, which is what almost everything actually
+//! uses: `Span::render_ref` appends zero-width graphemes to the preceding cell,
+//! and an ESC is zero-width. The crossterm backend then writes each cell symbol
+//! out with `Print`, unfiltered, and the escape reaches the terminal intact.
+//!
+//! Sanitising at the roughly two hundred places that build a `Span` would work
+//! until someone adds the two hundred and first. So the sweep happens once, at
+//! the end of `App::render`, over the finished buffer. Every path into the
+//! screen has converged by then, including paths added later and paths nobody
+//! remembered to audit.
+//!
+//! [`Buffer::set_stringn`]: ratatui::buffer::Buffer::set_stringn
+
+use ratatui::buffer::Buffer;
+
+/// What a stripped control character is replaced with.
+///
+/// A visible marker rather than deletion: silently dropping bytes would let a
+/// hostile value disguise itself as a different, plausible value. Seeing
+/// `total: 1<?>0` is a hint that something is wrong with the data, where
+/// `total: 10` is a lie.
+const REPLACEMENT: char = '\u{fffd}';
+
+/// True for characters that must never reach the terminal from untrusted text.
+///
+/// The C0 controls, DEL, and the C1 range, which some terminals accept as
+/// single-byte equivalents of the two-byte escape sequences (`\u{009b}` for
+/// CSI, for instance). Tab is allowed through: it is layout rather than
+/// control, and ratatui may place one legitimately.
+#[inline]
+fn is_forbidden(c: char) -> bool {
+    let n = c as u32;
+    (n < 0x20 && c != '\t') || n == 0x7f || (0x80..=0x9f).contains(&n)
+}
+
+/// Returns a display-safe copy of `s`, or `None` if it was already safe.
+///
+/// The `None` case is the common one by a wide margin, and returning it avoids
+/// allocating for the overwhelming majority of cells.
+pub fn sanitized(s: &str) -> Option<String> {
+    if !s.chars().any(is_forbidden) {
+        return None;
+    }
+    Some(
+        s.chars()
+            .map(|c| if is_forbidden(c) { REPLACEMENT } else { c })
+            .collect(),
+    )
+}
+
+/// Replaces control characters in every cell of a finished buffer.
+///
+/// Call this once, after all rendering, and before the buffer is handed to a
+/// backend. It is the last point at which datui controls what the terminal
+/// receives.
+pub fn sanitize_buffer(buf: &mut Buffer) {
+    for cell in buf.content.iter_mut() {
+        if let Some(clean) = sanitized(cell.symbol()) {
+            cell.set_symbol(&clean);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ratatui::layout::Rect;
+
+    #[test]
+    fn leaves_ordinary_text_alone() {
+        assert_eq!(sanitized("hello"), None);
+        assert_eq!(sanitized(""), None);
+        // Tab is layout, not control.
+        assert_eq!(sanitized("a\tb"), None);
+        // Non-ASCII text must survive untouched.
+        assert_eq!(sanitized("héllo · 日本語 · 🦀"), None);
+    }
+
+    #[test]
+    fn replaces_c0_controls() {
+        assert_eq!(sanitized("\x1b[2J").unwrap(), "\u{fffd}[2J");
+        assert_eq!(sanitized("a\x07b").unwrap(), "a\u{fffd}b");
+        assert_eq!(sanitized("a\rb").unwrap(), "a\u{fffd}b");
+        assert_eq!(sanitized("a\nb").unwrap(), "a\u{fffd}b");
+        assert_eq!(sanitized("a\x00b").unwrap(), "a\u{fffd}b");
+    }
+
+    #[test]
+    fn replaces_del_and_c1() {
+        assert_eq!(sanitized("a\x7fb").unwrap(), "a\u{fffd}b");
+        // Single-byte CSI, accepted by some terminals.
+        assert_eq!(sanitized("\u{009b}31m").unwrap(), "\u{fffd}31m");
+        assert_eq!(sanitized("\u{0080}").unwrap(), "\u{fffd}");
+        assert_eq!(sanitized("\u{009f}").unwrap(), "\u{fffd}");
+    }
+
+    #[test]
+    fn keeps_the_character_after_the_c1_range() {
+        // U+00A0 is a no-break space, not a control. Off-by-one guard.
+        assert_eq!(sanitized("\u{00a0}"), None);
+    }
+
+    #[test]
+    fn sweeps_a_whole_buffer() {
+        let mut buf = Buffer::empty(Rect::new(0, 0, 4, 1));
+        buf[(0, 0)].set_symbol("a");
+        buf[(1, 0)].set_symbol("\x1b");
+        // A cell symbol can hold several graphemes: Span rendering appends
+        // zero-width ones to the preceding cell, which is how an escape gets
+        // in alongside a visible character in the first place.
+        buf[(2, 0)].set_symbol("b\x1b]52;c;x\x07");
+        buf[(3, 0)].set_symbol("c");
+
+        sanitize_buffer(&mut buf);
+
+        assert_eq!(buf[(0, 0)].symbol(), "a");
+        assert_eq!(buf[(1, 0)].symbol(), "\u{fffd}");
+        assert_eq!(buf[(2, 0)].symbol(), "b\u{fffd}]52;c;x\u{fffd}");
+        assert_eq!(buf[(3, 0)].symbol(), "c");
+    }
+}

--- a/tests/terminal_escape_test.rs
+++ b/tests/terminal_escape_test.rs
@@ -1,0 +1,193 @@
+//! Terminal escape sequence injection.
+//!
+//! datui renders untrusted text by definition: cell values, column names and
+//! filenames all come from whatever the user opened. If any of that reaches the
+//! terminal without being neutralised, a hostile dataset stops being data and
+//! starts being commands. Depending on the terminal that means a spoofed
+//! interface, a clipboard write via OSC 52, a window title change, or worse.
+//!
+//! This is the classic vulnerability class for anything that displays text it
+//! did not write, so it gets a test rather than an assumption.
+//!
+//! Everything asserted here goes through the real render path: load a file,
+//! render the App into a ratatui Buffer, and inspect the symbols that would be
+//! written to the terminal.
+
+use datui::{App, AppEvent, OpenOptions};
+use ratatui::buffer::Buffer;
+use ratatui::layout::Rect;
+use ratatui::widgets::Widget;
+use std::path::PathBuf;
+use std::sync::mpsc;
+
+mod common;
+
+/// Sequences worth trying, and what each would do if it escaped.
+///
+/// The names matter more than the bytes: a future reader should be able to see
+/// what capability each one is reaching for.
+const PAYLOADS: &[(&str, &str)] = &[
+    ("CSI clear screen", "\x1b[2J"),
+    ("CSI cursor home", "\x1b[H"),
+    ("CSI red text", "\x1b[31m"),
+    ("OSC 52 clipboard write", "\x1b]52;c;aGVsbG8=\x07"),
+    ("OSC 0 window title", "\x1b]0;pwned\x07"),
+    (
+        "OSC 8 hyperlink",
+        "\x1b]8;;http://evil.example\x07link\x1b]8;;\x07",
+    ),
+    ("DCS passthrough", "\x1bPq\x1b\\"),
+    ("bare ESC", "\x1b"),
+    ("BEL", "\x07"),
+    ("carriage return", "line1\rline2"),
+    ("backspace overwrite", "safe\x08\x08\x08\x08evil"),
+    ("C1 CSI single byte", "\u{009b}31m"),
+];
+
+fn pump_open_until_loaded(
+    app: &mut App,
+    rx: &std::sync::mpsc::Receiver<AppEvent>,
+    paths: Vec<PathBuf>,
+    options: OpenOptions,
+) {
+    let mut next: Option<AppEvent> = Some(AppEvent::Open(paths, options));
+    loop {
+        if let Some(ev) = next.take() {
+            if matches!(ev, AppEvent::Crash(_)) {
+                app.event(&ev);
+                return;
+            }
+            next = app.event(&ev);
+        } else {
+            match rx.recv_timeout(std::time::Duration::from_millis(2000)) {
+                Ok(ev) => next = Some(ev),
+                Err(_) => return,
+            }
+        }
+    }
+}
+
+/// Every symbol the buffer would emit, concatenated.
+fn rendered_text(buf: &Buffer) -> String {
+    buf.content().iter().map(|cell| cell.symbol()).collect()
+}
+
+/// The characters that must never reach the terminal from untrusted text.
+///
+/// C0 controls other than tab, plus DEL and the C1 range. Tab is excluded
+/// because it is layout, not control, and ratatui may legitimately place one.
+fn offending_chars(s: &str) -> Vec<char> {
+    s.chars()
+        .filter(|c| {
+            let n = *c as u32;
+            (n < 0x20 && *c != '\t') || n == 0x7f || (0x80..=0x9f).contains(&n)
+        })
+        .collect()
+}
+
+fn write_csv(name: &str, contents: &str) -> PathBuf {
+    let dir = std::env::temp_dir().join(format!("datui-escape-test-{}", std::process::id()));
+    std::fs::create_dir_all(&dir).expect("create temp dir");
+    let path = dir.join(name);
+    std::fs::write(&path, contents).expect("write fixture");
+    path
+}
+
+fn render_file(path: PathBuf, width: u16) -> String {
+    common::isolate_cache();
+    let (tx, rx) = mpsc::channel();
+    let mut app = App::new(tx, common::test_runtime());
+    pump_open_until_loaded(&mut app, &rx, vec![path], OpenOptions::default());
+
+    let area = Rect::new(0, 0, width, 40);
+    let mut buf = Buffer::empty(area);
+    Widget::render(&mut app, area, &mut buf);
+    rendered_text(&buf)
+}
+
+/// CSV-quote a field, so the parser hands the payload through as one value.
+fn quoted(payload: &str) -> String {
+    format!("\"{}\"", payload.replace('"', "\"\""))
+}
+
+#[test]
+fn cell_values_cannot_emit_escape_sequences() {
+    // One row per payload, one load. Also closer to a real hostile file, which
+    // would not politely contain a single bad cell.
+    let mut csv = String::from("id,note\n");
+    for (i, (_, payload)) in PAYLOADS.iter().enumerate() {
+        csv.push_str(&format!("{},{}\n", i, quoted(payload)));
+    }
+    let path = write_csv("cells.csv", &csv);
+
+    let text = render_file(path, 120);
+    let offenders = offending_chars(&text);
+    assert!(
+        offenders.is_empty(),
+        "control chars {:?} reached the terminal from cell values; payloads were {:?}",
+        offenders,
+        PAYLOADS.iter().map(|(n, _)| *n).collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn column_names_cannot_emit_escape_sequences() {
+    // Headers take a different path to the screen than cell values: they are
+    // drawn as table headers and reused in modals and menus. A wide viewport so
+    // that every column is actually on screen and therefore actually rendered.
+    let headers: Vec<String> = PAYLOADS.iter().map(|(_, p)| quoted(p)).collect();
+    let values: Vec<&str> = PAYLOADS.iter().map(|_| "x").collect();
+    let csv = format!("{}\n{}\n", headers.join(","), values.join(","));
+    let path = write_csv("headers.csv", &csv);
+
+    let text = render_file(path, 400);
+    let offenders = offending_chars(&text);
+    assert!(
+        offenders.is_empty(),
+        "control chars {:?} reached the terminal from column names",
+        offenders
+    );
+}
+
+#[test]
+fn filenames_cannot_emit_escape_sequences() {
+    // The filename is shown in the header bar, and lands in the recent-files
+    // list on the home screen. It is attacker-influenced whenever someone opens
+    // a file they were sent.
+    let path = write_csv("na\x1b[31mme.csv", "id,note\n1,x\n");
+
+    let text = render_file(path, 120);
+    let offenders = offending_chars(&text);
+    assert!(
+        offenders.is_empty(),
+        "an escape sequence in a filename survived rendering as {:?}",
+        offenders
+    );
+}
+
+#[test]
+fn error_messages_cannot_emit_escape_sequences() {
+    // Error paths are where raw untrusted strings usually leak through, since
+    // they tend to interpolate a filename or a parser message directly.
+    let dir = std::env::temp_dir().join(format!("datui-escape-test-{}", std::process::id()));
+    std::fs::create_dir_all(&dir).expect("create temp dir");
+    let missing = dir.join("no\x1b]0;pwned\x07such.csv");
+
+    let text = render_file(missing, 120);
+    let offenders = offending_chars(&text);
+    assert!(
+        offenders.is_empty(),
+        "an escape sequence in an error message survived rendering as {:?}",
+        offenders
+    );
+}
+
+#[test]
+fn the_detector_would_catch_a_real_escape() {
+    // Guards the guard. If offending_chars ever stopped matching, every test
+    // above would pass vacuously.
+    assert!(!offending_chars("\x1b[2J").is_empty());
+    assert!(!offending_chars("\x07").is_empty());
+    assert!(!offending_chars("\u{009b}").is_empty());
+    assert!(offending_chars("ordinary text\tand a tab").is_empty());
+}


### PR DESCRIPTION
Phase 2 of the security review, terminal rendering. This is a real vulnerability in released versions, not hardening.

## The bug

A terminal does not distinguish text from commands. datui displays text it did not write, so a file could send commands to the terminal of whoever opened it.

Affected paths: **cell values, column names, filenames, and error messages.**

| Payload in a cell | Effect |
|---|---|
| `\x1b]52;c;<base64>\x07` | Writes to the user's clipboard |
| `\x1b[2J` | Clears the screen |
| `\x1b]0;...\x07` | Changes the window title |
| `\x1b[...m` plus cursor moves | Spoofs the interface |

The clipboard case is the serious one. A hostile spreadsheet plants a command, and the user runs it themselves on their next paste.

## Why it was there

The defence looks present. ratatui strips control characters in `Buffer::set_stringn`.

It does not strip them in `Span` and `Line` rendering, which is what every widget here actually uses. An escape character has zero display width, so `Span::render_ref` **appends** it onto the preceding cell rather than dropping it. `CrosstermBackend::draw` then writes each cell symbol with `Print` and no filtering.

I read all three functions rather than inferring the path.

## The fix

One sweep over the finished buffer, as the last statement of `App::render`.

There are around 200 `Span` construction sites across 11 files. Sanitising at each would hold until someone added the 201st. At the end of render every path to the screen has converged, including ones added later, so a new widget cannot forget to be safe.

Control characters become U+FFFD rather than being deleted. Silently dropping bytes would let a hostile value disguise itself as a different plausible one; `total: 1<?>0` says something is wrong with the data, where `total: 10` is a lie. Tab passes through as layout.

## Evidence the tests work

`tests/terminal_escape_test.rs` drives the real render path with 12 payloads covering CSI, OSC 52, OSC 0, OSC 8, DCS and the single-byte C1 forms, across all four affected paths.

**All four tests were confirmed to fail with the sweep removed.** A fifth test checks the detector itself still matches a real escape, so the other four cannot pass by silently testing nothing.

## The chart export, where the bug was not

You asked me to check the EPS export next, since chart labels are also untrusted, PostScript is a programming language, and an exported chart gets opened by other people.

`ps_escape` already handles it correctly. It escapes backslash **before** the parentheses, which is the order that works. All fifteen text-drawing calls use it. No data reaches the DSC comments, where a newline would end a comment and begin code.

Nothing to fix, so this adds tests to keep it that way: a real PostScript literal scanner that tracks escaping, plus unit tests for `ps_escape` itself.

**Worth flagging: those tests took two attempts.** The first version passed even with `ps_escape` deliberately removed. The payload put its marker inside parentheses, where an interpreter treats it as inert text and my scanner correctly ignored it. A marker only demonstrates injection if it lands **outside** a string literal. Corrected, then confirmed to fail with the escaping removed. A test that cannot fail is worse than no test, because it reports safety it never checked.

## Verification

- 581 tests pass, no failures.
- Every new test confirmed to fail when its protection is removed.
- clippy with `-D warnings` and `cargo fmt --check` green.

## Note for the release

You chose to fix this quietly in the next planned release rather than publishing an advisory. Two consequences worth keeping in view:

- Users on 0.3.1 get no signal to upgrade, so the release notes should call this a **security fix** plainly rather than describing it as a rendering change.
- The release workflow has not run since it was hardened in #59, so shipping 0.3.2 is also the first live test of that pipeline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T3dG16ZsDzbMnN2yJtdYw4
