### PR TITLE
Stop a third-party apt repository from failing the build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,7 +47,13 @@ jobs:
         with:
           toolchain: stable
       - name: Install system dependencies
-        run: sudo apt-get update && sudo apt-get install -y pkg-config libfontconfig1-dev
+        run: |
+          # The runner image ships third-party apt repositories datui does not use (Chrome, for one).
+          # When one of those serves a bad index, `apt-get update` exits non-zero and fails a build
+          # that had nothing to do with it. The install below is the real gate: if Ubuntu's own
+          # indexes did not fetch, it fails there, for the right reason.
+          sudo apt-get update || echo '::warning::apt-get update reported errors; continuing'
+          sudo apt-get install -y pkg-config libfontconfig1-dev
 
       - name: Cache cargo dependencies
         uses: swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
@@ -84,7 +90,13 @@ jobs:
         uses: mozilla-actions/sccache-action@9e7fa8a12102821edf02ca5dbea1acd0f89a2696 # v0.0.10
 
       - name: Install system dependencies
-        run: sudo apt-get update && sudo apt-get install -y pkg-config libfontconfig1-dev python3-dev
+        run: |
+          # The runner image ships third-party apt repositories datui does not use (Chrome, for one).
+          # When one of those serves a bad index, `apt-get update` exits non-zero and fails a build
+          # that had nothing to do with it. The install below is the real gate: if Ubuntu's own
+          # indexes did not fetch, it fails there, for the right reason.
+          sudo apt-get update || echo '::warning::apt-get update reported errors; continuing'
+          sudo apt-get install -y pkg-config libfontconfig1-dev python3-dev
 
       - name: Set up Python
         uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -41,7 +41,13 @@ jobs:
         uses: mozilla-actions/sccache-action@9e7fa8a12102821edf02ca5dbea1acd0f89a2696 # v0.0.10
 
       - name: Install system dependencies
-        run: sudo apt-get update && sudo apt-get install -y pkg-config libfontconfig1-dev python3-dev
+        run: |
+          # The runner image ships third-party apt repositories datui does not use (Chrome, for one).
+          # When one of those serves a bad index, `apt-get update` exits non-zero and fails a build
+          # that had nothing to do with it. The install below is the real gate: if Ubuntu's own
+          # indexes did not fetch, it fails there, for the right reason.
+          sudo apt-get update || echo '::warning::apt-get update reported errors; continuing'
+          sudo apt-get install -y pkg-config libfontconfig1-dev python3-dev
 
       - name: Set up Python
         uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0

--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -96,7 +96,13 @@ jobs:
         with:
           toolchain: stable
       - name: Install system dependencies
-        run: sudo apt-get update && sudo apt-get install -y pkg-config libfontconfig1-dev
+        run: |
+          # The runner image ships third-party apt repositories datui does not use (Chrome, for one).
+          # When one of those serves a bad index, `apt-get update` exits non-zero and fails a build
+          # that had nothing to do with it. The install below is the real gate: if Ubuntu's own
+          # indexes did not fetch, it fails there, for the right reason.
+          sudo apt-get update || echo '::warning::apt-get update reported errors; continuing'
+          sudo apt-get install -y pkg-config libfontconfig1-dev
 
       - name: Publish to crates.io
         env:
@@ -377,7 +383,11 @@ jobs:
     steps:
       - name: Install APT tools
         run: |
-          sudo apt-get update
+          # The runner image ships third-party apt repositories datui does not use (Chrome, for one).
+          # When one of those serves a bad index, `apt-get update` exits non-zero and fails a build
+          # that had nothing to do with it. The install below is the real gate: if Ubuntu's own
+          # indexes did not fetch, it fails there, for the right reason.
+          sudo apt-get update || echo '::warning::apt-get update reported errors; continuing'
           sudo apt-get install -y dpkg-dev apt-utils gpg
 
       - name: Import GPG key

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -68,7 +68,13 @@ jobs:
         uses: mozilla-actions/sccache-action@9e7fa8a12102821edf02ca5dbea1acd0f89a2696 # v0.0.10
 
       - name: Install system dependencies
-        run: sudo apt-get update && sudo apt-get install -y pkg-config libfontconfig1-dev python3-dev
+        run: |
+          # The runner image ships third-party apt repositories datui does not use (Chrome, for one).
+          # When one of those serves a bad index, `apt-get update` exits non-zero and fails a build
+          # that had nothing to do with it. The install below is the real gate: if Ubuntu's own
+          # indexes did not fetch, it fails there, for the right reason.
+          sudo apt-get update || echo '::warning::apt-get update reported errors; continuing'
+          sudo apt-get install -y pkg-config libfontconfig1-dev python3-dev
 
       - name: Set up Python
         uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0


### PR DESCRIPTION
Stop a third-party apt repository from failing the build

CI is currently red on every Linux job, and not for any reason to do with
datui. The GitHub runner image ships Google Chrome's apt repository
preconfigured, that repository is serving a Packages.gz whose hash does not
match its own Release file, and so `apt-get update` exits 100. Ubuntu's own
indexes fetched fine in the same run.

Every Linux job begins with `apt-get update && apt-get install`, so an outage
in a third party's CDN takes out the `check` job, which then skips `linux`,
`macos` and `windows` through `needs`. One vendor datui does not depend on can
stop anything from merging, including a security fix.

The install is the real gate, so let it be the gate. `apt-get update` failing
now emits a workflow warning and carries on; if Ubuntu's indexes genuinely did
not fetch, `apt-get install` fails on the next line, for the right reason and
with a message that names the missing package.

Applied at all six call sites across ci, nightly, release and
publish-packages.

Not fixed by pinning or removing the offending repository: the specific vendor
is incidental, and the next one will be a different name in a different
release. What matters is that a repository datui does not use cannot decide
whether datui builds.

Verified: all workflow files parse, and the zizmor gate still reports nothing at high severity.

This unblocks #80, which is currently red for this reason alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T3dG16ZsDzbMnN2yJtdYw4