### PR TITLE
Keep credentials and downloaded data out of other people's reach

### DIFF
--- a/crates/datui-lib/examples/sanitize_cost.rs
+++ b/crates/datui-lib/examples/sanitize_cost.rs
@@ -1,0 +1,71 @@
+//! Measures what the render-time control-character sweep costs.
+//!
+//! Run with: cargo run --release -p datui-lib --example sanitize_cost
+
+use datui_lib::sanitize::sanitize_buffer;
+use ratatui::buffer::Buffer;
+use ratatui::layout::Rect;
+use std::time::Instant;
+
+fn filled(w: u16, h: u16, sample: &[&str]) -> Buffer {
+    let mut buf = Buffer::empty(Rect::new(0, 0, w, h));
+    for (i, cell) in buf.content.iter_mut().enumerate() {
+        cell.set_symbol(sample[i % sample.len()]);
+    }
+    buf
+}
+
+fn bench(name: &str, w: u16, h: u16, sample: &[&str]) {
+    let template = filled(w, h, sample);
+    let cells = (w as usize) * (h as usize);
+
+    // Warm up, so the first run's page faults are not in the measurement.
+    for _ in 0..20 {
+        let mut b = template.clone();
+        sanitize_buffer(&mut b);
+    }
+
+    const FRAMES: u32 = 2000;
+    let start = Instant::now();
+    for _ in 0..FRAMES {
+        let mut b = template.clone();
+        sanitize_buffer(&mut b);
+    }
+    let total = start.elapsed();
+
+    // Clone cost is measured separately and subtracted: the real render path
+    // sweeps a buffer it already owns, so cloning is this harness, not the fix.
+    let start = Instant::now();
+    for _ in 0..FRAMES {
+        let b = template.clone();
+        std::hint::black_box(&b);
+    }
+    let clone_only = start.elapsed();
+
+    let per_frame = total.saturating_sub(clone_only) / FRAMES;
+    println!(
+        "{name:<34} {w}x{h} = {cells:>6} cells   {:>9.1?} per frame",
+        per_frame
+    );
+}
+
+fn main() {
+    // Ordinary content: one plain character per cell, nothing to replace. This
+    // is what essentially every real frame looks like.
+    let plain = ["a", "b", " ", "1", "x", "·"];
+    // Wide characters and combining marks, to check the grapheme path.
+    let unicode = ["日", "é", "🦀", "a\u{0301}", " ", "─"];
+    // Every cell hostile. Not a realistic frame; an upper bound.
+    let hostile = ["\x1b", "a\x1b[2J", "\x07", "b\u{009b}", "\x7f", "c"];
+
+    println!("plain content (the realistic case)");
+    bench("  80x24 laptop split pane", 80, 24, &plain);
+    bench("  200x50 full screen", 200, 50, &plain);
+    bench("  400x100 large monitor", 400, 100, &plain);
+
+    println!("\nunicode content");
+    bench("  200x50 full screen", 200, 50, &unicode);
+
+    println!("\nevery cell hostile (upper bound)");
+    bench("  200x50 full screen", 200, 50, &hostile);
+}

--- a/crates/datui-lib/src/config.rs
+++ b/crates/datui-lib/src/config.rs
@@ -357,7 +357,7 @@ impl ConfigManager {
 
         // Generate and write default template
         let template = self.generate_default_config();
-        std::fs::write(&config_path, template)?;
+        write_private(&config_path, &template)?;
 
         Ok(config_path)
     }
@@ -465,6 +465,45 @@ pub struct CloudConfig {
     pub s3_region: Option<String>,
 }
 
+/// Write `contents` to `path`, readable only by the owner.
+///
+/// The generated config carries a `[cloud]` section inviting an S3 access key
+/// and secret. A plain `fs::write` creates the file at 0666 minus the umask,
+/// which on most systems is 0644: world-readable. On a machine with more than
+/// one account that hands the user's credentials to everybody, and it is not a
+/// choice the user made knowingly, since datui is the one that wrote the file.
+///
+/// The mode is applied twice on purpose. `OpenOptions::mode` only takes effect
+/// when the file is created, so it does nothing for `--generate-config --force`
+/// over a config that already exists at 0644; `set_permissions` fixes that
+/// case. Creating with the mode still matters, because it closes the window
+/// where a new file exists at 0644 before the permissions are corrected.
+///
+/// Non-Unix platforms fall back to a plain write: Windows inherits ACLs from
+/// the containing directory, which is already per-user.
+fn write_private(path: &Path, contents: &str) -> Result<()> {
+    #[cfg(unix)]
+    {
+        use std::io::Write;
+        use std::os::unix::fs::{OpenOptionsExt, PermissionsExt};
+
+        let mut file = std::fs::OpenOptions::new()
+            .write(true)
+            .create(true)
+            .truncate(true)
+            .mode(0o600)
+            .open(path)?;
+        file.write_all(contents.as_bytes())?;
+        file.sync_all()?;
+        std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o600))?;
+    }
+    #[cfg(not(unix))]
+    {
+        std::fs::write(path, contents)?;
+    }
+    Ok(())
+}
+
 const CLOUD_COMMENTS: &[(&str, &str)] = &[
     (
         "s3_endpoint_url",
@@ -476,7 +515,7 @@ const CLOUD_COMMENTS: &[(&str, &str)] = &[
     ),
     (
         "s3_secret_access_key",
-        "Secret key when using custom endpoint (or set AWS_SECRET_ACCESS_KEY).",
+        "Secret key when using custom endpoint. Prefer AWS_SECRET_ACCESS_KEY, or the usual AWS credential chain: a secret written here sits in a plain file that backups and dotfile repos will happily copy.",
     ),
     (
         "s3_region",

--- a/crates/datui-lib/src/lib.rs
+++ b/crates/datui-lib/src/lib.rs
@@ -9785,6 +9785,27 @@ impl Widget for &mut App {
     }
 }
 
+impl Drop for App {
+    fn drop(&mut self) {
+        // Opening a remote file downloads it to a temp file so Polars can scan
+        // it lazily. Opening a *different* file removes the previous one, which
+        // is what `AppEvent::Open` does, but quitting removed nothing: the last
+        // dataset someone viewed stayed in the temp directory until something
+        // else cleared it. The file is mode 0600, so this is disk hygiene
+        // rather than exposure, but the contents are the user's data and they
+        // did not ask for a copy to be left behind.
+        //
+        // Drop rather than the end of `run`, because it is the one place that
+        // covers every exit: a normal quit, an error return, an unwind from a
+        // panic, and the Python binding calling `run` again in the same
+        // process.
+        #[cfg(feature = "http")]
+        if let Some(path) = self.http_temp_path.take() {
+            let _ = std::fs::remove_file(path);
+        }
+    }
+}
+
 /// Run the TUI with either file paths or an existing LazyFrame. Single event loop used by CLI and Python binding.
 pub fn run(input: RunInput, config: Option<AppConfig>) -> Result<()> {
     use std::io::Write;

--- a/tests/config_test.rs
+++ b/tests/config_test.rs
@@ -1643,3 +1643,78 @@ extensions = ["parquet"]
         .skipped_dirs()
         .contains(&"archive".to_string()));
 }
+
+/// The generated config invites an S3 access key and secret in its `[cloud]`
+/// section. datui creates that file, so datui decides who can read it: a plain
+/// write lands at 0644 under a typical umask, which hands the user's
+/// credentials to every other account on the machine.
+#[cfg(unix)]
+#[test]
+fn generated_config_is_not_readable_by_other_users() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let (_temp_dir, config_manager) = setup_test_config_dir();
+    let path = config_manager
+        .write_default_config(false)
+        .expect("write default config");
+
+    let mode = fs::metadata(&path)
+        .expect("stat config")
+        .permissions()
+        .mode();
+    assert_eq!(
+        mode & 0o777,
+        0o600,
+        "config should be owner-only, got {:o}",
+        mode & 0o777
+    );
+}
+
+/// `--generate-config --force` overwrites a file that already exists, and
+/// `OpenOptions::mode` only applies when creating. Without an explicit
+/// `set_permissions`, a config first written by an older datui would keep its
+/// 0644 forever.
+#[cfg(unix)]
+#[test]
+fn regenerating_over_a_world_readable_config_tightens_it() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let (_temp_dir, config_manager) = setup_test_config_dir();
+    let path = config_manager
+        .write_default_config(false)
+        .expect("write default config");
+
+    // Simulate a config left behind by a version that wrote 0644.
+    fs::set_permissions(&path, fs::Permissions::from_mode(0o644)).expect("loosen");
+    assert_eq!(
+        fs::metadata(&path).unwrap().permissions().mode() & 0o777,
+        0o644
+    );
+
+    config_manager
+        .write_default_config(true)
+        .expect("regenerate with force");
+
+    assert_eq!(
+        fs::metadata(&path).unwrap().permissions().mode() & 0o777,
+        0o600,
+        "regenerating should tighten an existing world-readable config"
+    );
+}
+
+/// The template is what steers people toward putting a secret in this file at
+/// all, so it should say where the secret is better kept.
+#[test]
+fn cloud_secret_comment_points_at_the_environment() {
+    let (_temp_dir, config_manager) = setup_test_config_dir();
+    let template = config_manager.generate_default_config();
+
+    assert!(
+        template.contains("s3_secret_access_key"),
+        "template should carry the cloud credential fields"
+    );
+    assert!(
+        template.contains("AWS_SECRET_ACCESS_KEY"),
+        "template should name the environment variable as the better home for a secret"
+    );
+}


### PR DESCRIPTION
Two small findings from the Phase 2 review, both about files datui creates on the user's behalf.

## Config files can hold credentials and were world-readable

`--generate-config` writes a template that invites an S3 access key and secret in its `[cloud]` section, using a plain `fs::write`. That lands at 0666 minus the umask, so **0644 on most systems**.

Nothing secret is in the file at creation, since every line starts commented out. But datui chose the mode, and it chose one that hands the user's credentials to every other account on the machine the moment they follow the template it wrote for them.

Now created 0600. The mode is applied twice on purpose:

- `OpenOptions::mode` only takes effect when a file is **created**, so it does nothing for `--generate-config --force` over a config an older datui already left at 0644.
- `set_permissions` covers that case, and creating with the mode still matters because it closes the window where a new file briefly exists world-readable.

Non-Unix falls back to a plain write, since Windows inherits per-user ACLs from the containing directory.

The comment on `s3_secret_access_key` now says where a secret is better kept. That comment is what steers people into using this file at all, so it is the right place to name the environment variable and to mention that a plain file gets copied by backups and dotfile repositories.

**Severity: low.** It needs a multi-user machine, a user who picks the config file over the environment, and another local account that cares. On a single-user laptop it is nothing. It is fixed because it is cheap, not because it is urgent.

## Downloaded files outlived the session

Opening a remote file downloads it to a temp file so Polars can scan it lazily. Only the *next* open removed it, so quitting removed nothing and the last dataset viewed stayed in the temp directory until something else cleared it.

The field's own doc comment already claimed it was removed "when user opens different data or exits". The exit half was never implemented.

Now handled in `Drop`, which is the one place covering every exit: a normal quit, an error return, an unwind from a panic, and the Python binding calling `run` again in the same process. The file is mode 0600, so this is disk hygiene rather than exposure, but it is the user's data and they did not ask for a copy to be left behind.

## A benchmark for the previous change

Also adds `examples/sanitize_cost.rs`, measuring what the render-time control-character sweep from #80 actually costs, so the claim that it is free can be rechecked rather than trusted.

| Terminal | Cells | Per frame |
|---|---|---|
| 80x24 | 1,920 | 4.7 µs |
| 200x50 | 10,000 | 24.6 µs |
| 400x100 | 40,000 | 99.1 µs |

A 60fps budget is 16,700 µs, and datui only redraws on input. Unicode content costs 28.7 µs against 24.6 for plain, so wide characters are not a slow path. Every cell hostile, which is not a real frame, is 139.5 µs.

The cost scales with **screen size, not dataset size**, so it cannot grow with a larger file. Happy to drop this file if you would rather it not ship.

## Verification

- 584 tests pass, including three new ones covering the config mode.
- One test specifically checks that regenerating over a world-readable config **tightens** it, which is the case `OpenOptions::mode` alone would miss.
- clippy with `-D warnings` and `cargo fmt --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T3dG16ZsDzbMnN2yJtdYw4
