### PR TITLE
Stop Dependabot proposing version-coupled bumps on their own

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,6 +18,11 @@ updates:
       cargo-minor-and-patch:
         update-types: [minor, patch]
     labels: [dependencies, rust]
+    ignore:
+      # polars-sql has to be the same version as polars. Bumped on its own it
+      # pulls a second polars-core into the tree and does not compile. It moves
+      # when polars moves, as one deliberate upgrade.
+      - dependency-name: "polars-sql"
 
   # datui-pyo3 is excluded from the root workspace and has its own lockfile, so
   # Dependabot has to be pointed at it separately.
@@ -31,6 +36,9 @@ updates:
       cargo-minor-and-patch:
         update-types: [minor, patch]
     labels: [dependencies, rust, python-bindings]
+    ignore:
+      # Same coupling as the root workspace: polars-sql tracks polars.
+      - dependency-name: "polars-sql"
 
   # GitHub Actions: SHA pins do not update themselves. This is the job that
   # keeps a pinned action from silently rotting on a version with a known bug.
@@ -43,12 +51,21 @@ updates:
     labels: [dependencies, ci]
 
   # The Python package and the build/release helper scripts.
+  #
+  # Python polars is pinned to match the Rust polars version in both places.
+  # `datui.view(lazyframe)` serializes a query plan in Python and deserializes
+  # it in Rust, so the two sides have to agree on the plan format. A one-sided
+  # bump breaks that at runtime for users rather than at compile time in CI,
+  # which is the worst place to find out. Python polars moves when Rust polars
+  # moves.
   - package-ecosystem: pip
     directory: "/python"
     schedule:
       interval: weekly
       day: monday
     labels: [dependencies, python]
+    ignore:
+      - dependency-name: "polars"
 
   - package-ecosystem: pip
     directory: "/scripts"
@@ -56,3 +73,5 @@ updates:
       interval: weekly
       day: monday
     labels: [dependencies, python, ci]
+    ignore:
+      - dependency-name: "polars"


### PR DESCRIPTION
Three Dependabot pull requests could never be merged, and without this they would come back every Monday.

**`polars-sql` has to be the same version as `polars`.** Bumped alone it pulls a second `polars-core` into the tree and does not compile. That is why #75 and #77 failed their `check` job rather than flaking on infrastructure like the others did.

**Python polars is pinned to match Rust polars**, in both the package and the build scripts. `datui.view(lazyframe)` serializes a query plan in Python and deserializes it in Rust, so both sides must agree on the plan format. A one-sided bump, which is what #62 proposed, breaks that **at runtime for users** rather than at compile time in CI. That is the worst place to find out, so the reasoning is written into the config next to the rule rather than left in a closed PR.

Both dependencies move when their partner moves, as one deliberate upgrade. The rule is not "never update these"; it is "do not update these in isolation".

I closed #62, #75 and #77 with the same explanation.

Verified the config parses and the ignore rules land on the intended four ecosystems.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T3dG16ZsDzbMnN2yJtdYw4