### PR TITLE
Allow the bzip2 licence, and unbreak main

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -100,6 +100,12 @@ allow = [
     # webpki-roots: the Mozilla CA certificate bundle. A permissive data
     # license, not a code license, and unavoidable for anything doing TLS.
     "CDLA-Permissive-2.0",
+    # libbz2-rs-sys, reached through bzip2 0.6. The original bzip2 licence:
+    # BSD-style, permissive, and the same terms the C libbz2 always shipped
+    # under. It appears in the tree now only because bzip2 0.6 replaced the C
+    # library with a pure-Rust implementation, which is a straight improvement
+    # on a path that parses untrusted input.
+    "bzip2-1.0.6",
 ]
 confidence-threshold = 0.8
 


### PR DESCRIPTION
**main is currently red on cargo-deny, and that is my fault.** I merged #86 while its `cargo-deny (bans licenses sources)` job was failing. When triaging the Dependabot queue I was checking only the `check` and `linux` jobs and never looked at the rest. Fixed my process; fixing the tree here.

## The bump itself is good, and better than it looked

bzip2 0.6 replaces the C libbz2 with a pure-Rust implementation, `libbz2-rs-sys`. `bzip2-sys`, the C bindings, are **gone from the lockfile entirely**.

That removes C code from a path that parses whatever file the user opened. Decompression of untrusted input is exactly where a memory-safety bug in this project would live, so this is a straight improvement rather than a routine version bump.

## What actually tripped the check

The new crate carries the original bzip2 licence: BSD-style, permissive, and the same terms the C library always shipped under. It simply was not in the allow list yet, because until now the tree had never contained it.

Verified locally: `advisories ok, bans ok, licenses ok, sources ok`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T3dG16ZsDzbMnN2yJtdYw4