### PR TITLE
Migrate to ureq 3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1400,7 +1400,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1484,7 +1484,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3675,7 +3675,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
 dependencies = [
  "anyhow",
- "itertools 0.13.0",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
  "syn 2.0.119",
@@ -3764,7 +3764,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4124,7 +4124,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4635,7 +4635,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5047,18 +5047,31 @@ checksum = "6d49784317cd0d1ee7ec5c716dd598ec5b4483ea832a2dced265471cc0f690ae"
 
 [[package]]
 name = "ureq"
-version = "2.12.1"
+version = "3.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02d1a66277ed75f640d608235660df48c8e3c19f3b4edb6a263315626cc3c01d"
+checksum = "af5546be8f5378d5414f83733f5c9a2526f4645829edbc1c41790aeef1b38e8b"
 dependencies = [
- "base64 0.22.1",
+ "base64 0.23.1",
  "flate2",
  "log",
- "once_cell",
+ "percent-encoding",
  "rustls",
  "rustls-pki-types",
- "url",
- "webpki-roots 0.26.11",
+ "ureq-proto",
+ "utf8-zero",
+ "webpki-roots",
+]
+
+[[package]]
+name = "ureq-proto"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fabc3e92916c89c95b20eef7b06b00b066bc217ef9ea3a4ac9bf1a7e35261e10"
+dependencies = [
+ "base64 0.23.1",
+ "http",
+ "httparse",
+ "log",
 ]
 
 [[package]]
@@ -5072,6 +5085,12 @@ dependencies = [
  "percent-encoding",
  "serde",
 ]
+
+[[package]]
+name = "utf8-zero"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8c0a043c9540bae7c578c88f91dda8bd82e59ae27c21baca69c8b191aaf5a6e"
 
 [[package]]
 name = "utf8_iter"
@@ -5251,15 +5270,6 @@ dependencies = [
 
 [[package]]
 name = "webpki-roots"
-version = "0.26.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
-dependencies = [
- "webpki-roots 1.0.9",
-]
-
-[[package]]
-name = "webpki-roots"
 version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7dcd9d09a39985f5344844e66b0c530a33843579125f23e21e9f0f220850f22a"
@@ -5295,7 +5305,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/crates/datui-lib/Cargo.toml
+++ b/crates/datui-lib/Cargo.toml
@@ -45,7 +45,7 @@ calamine = { version = "0.36", features = ["chrono"] }
 orc-rust = "0.9"
 arrow = "59"
 tempfile = "3.14"
-ureq = { version = "2.11", optional = true }
+ureq = { version = "3.4", optional = true }
 object_store = { version = "0.12", optional = true, default-features = false, features = ["aws", "gcp"] }
 tokio = { version = "1", features = ["rt-multi-thread", "rt", "io-util"] }
 polars-sql = { version = "0.52", optional = true }

--- a/crates/datui-lib/src/lib.rs
+++ b/crates/datui-lib/src/lib.rs
@@ -2678,14 +2678,34 @@ impl App {
         }
     }
 
+    /// Build an HTTP agent with a total time budget.
+    ///
+    /// ureq 3 moved timeouts off the request and onto agent configuration, so
+    /// every request has to come from an agent to be bounded at all. Leaving a
+    /// request unbounded would mean a remote that accepts a connection and then
+    /// dribbles bytes forever hangs the whole TUI, and the user's only way out
+    /// is to kill the process.
+    ///
+    /// `timeout_global` covers the entire exchange rather than individual
+    /// socket operations, which is the property that matters here: a server
+    /// that sends one byte every 29 seconds defeats a per-read timeout but not
+    /// this one.
+    #[cfg(feature = "http")]
+    fn http_agent(total: std::time::Duration) -> ureq::Agent {
+        ureq::Agent::config_builder()
+            .timeout_global(Some(total))
+            .build()
+            .into()
+    }
+
     #[cfg(feature = "http")]
     fn fetch_remote_size_http(url: &str) -> Result<Option<u64>> {
-        let response = ureq::request("HEAD", url)
-            .timeout(std::time::Duration::from_secs(15))
-            .call();
-        match response {
+        let agent = Self::http_agent(std::time::Duration::from_secs(15));
+        match agent.head(url).call() {
             Ok(r) => Ok(r
-                .header("Content-Length")
+                .headers()
+                .get("Content-Length")
+                .and_then(|v| v.to_str().ok())
                 .and_then(|s| s.parse::<u64>().ok())),
             Err(_) => Ok(None),
         }
@@ -2793,21 +2813,19 @@ impl App {
             .suffix(&suffix)
             .tempfile_in(&dir)
             .map_err(|_| color_eyre::eyre::eyre!("Could not create a temporary file."))?;
-        let response = ureq::get(url)
-            .timeout(std::time::Duration::from_secs(300))
-            .call()
-            .map_err(|e| {
-                color_eyre::eyre::eyre!("Download failed. Check the URL and your connection: {}", e)
-            })?;
+        let agent = Self::http_agent(std::time::Duration::from_secs(300));
+        let mut response = agent.get(url).call().map_err(|e| {
+            color_eyre::eyre::eyre!("Download failed. Check the URL and your connection: {}", e)
+        })?;
         let status = response.status();
-        if status >= 400 {
+        if status.is_client_error() || status.is_server_error() {
             return Err(color_eyre::eyre::eyre!(
                 "Server returned {} {}. Check the URL.",
-                status,
-                response.status_text()
+                status.as_u16(),
+                status.canonical_reason().unwrap_or("Unknown")
             ));
         }
-        std::io::copy(&mut response.into_reader(), &mut temp)
+        std::io::copy(&mut response.body_mut().as_reader(), &mut temp)
             .map_err(|_| color_eyre::eyre::eyre!("Download failed while saving the file."))?;
         let (_file, path) = temp
             .keep()


### PR DESCRIPTION
Dependabot could not do this one (#92, #93). ureq 3 needs source changes.

## What changed

Timeouts moved off the request and onto agent configuration, so both call sites now build an agent. That is a small improvement rather than a chore:

- A per-request timeout is something a future call site can forget to set. An agent carries it.
- `timeout_global` bounds the **whole exchange** rather than individual socket operations. A server that accepts the connection and then sends one byte every 29 seconds no longer hangs the TUI indefinitely, which a per-read timeout would not have caught.

The rest is mechanical. `ureq::request("HEAD", ..)` became `agent.head(..)`, headers come from `headers().get()` returning a `HeaderValue`, and the body reader is `body_mut().as_reader()`.

## Two things checked rather than assumed

Both of these would have failed **silently** rather than loudly, which is why they were worth chasing down in the ureq source rather than trusting the green tests.

**ureq 3 added a default 10MB body limit.** It applies to `read_to_string`, `read_to_vec` and `read_json`, not to the streaming reader used here, whose default limit is `u64::MAX`. Downloads of real datasets are not truncated. Had this applied, every remote file over 10MB would have been quietly cut short and parsed as corrupt.

**The upgrade drops `webpki-roots` from the tree**, which changes where TLS root certificates come from. ureq 3's default `TlsConfig` is `disable_verification: false` with `RootCerts::WebPki`, so verification is still on. Worth confirming rather than trusting, since "TLS verification is on by default" is something this review has already asserted publicly about datui in `SECURITY.md`.

## Verification

- 584 tests pass.
- clippy with `-D warnings` and `cargo fmt --check` clean.
- `cargo deny check`: advisories, bans, licenses, sources all clean.

Supersedes #92 and #93.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T3dG16ZsDzbMnN2yJtdYw4