### PR TITLE
Drop the pyo3 suppressions now that pyo3 0.29 has landed

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -44,17 +44,6 @@ ignore = [
     { id = "RUSTSEC-2026-0194", reason = "quick-xml DoS; xlsx path fixed by calamine 0.36, remaining copy is object_store S3/GCS XML, pinned by polars" },
     { id = "RUSTSEC-2026-0195", reason = "quick-xml DoS; xlsx path fixed by calamine 0.36, remaining copy is object_store S3/GCS XML, pinned by polars" },
 
-    # pyo3 0.26, in crates/datui-pyo3. Both are memory-safety bugs, patched in
-    # pyo3 0.29. Neither is reachable from this crate: the out-of-bounds read is
-    # in `nth` / `nth_back` on PyList and PyTuple iterators, and the missing
-    # Sync bound is on `PyCFunction::new_closure`. datui-pyo3 uses none of those
-    # APIs, which was checked against its source rather than assumed.
-    # Clears when: datui-pyo3 moves to pyo3 0.29, a breaking upgrade of the
-    # binding framework that needs the extension rebuilt and tested on every
-    # supported Python.
-    { id = "RUSTSEC-2026-0176", reason = "pyo3 OOB read in PyList/PyTuple nth; API not used by datui-pyo3" },
-    { id = "RUSTSEC-2026-0177", reason = "pyo3 missing Sync bound on new_closure; API not used by datui-pyo3" },
-
     # --- Unmaintained, no known vulnerability ---
 
     # ttf-parser, via plotters, used to lay out text when exporting a chart to


### PR DESCRIPTION
#72 bumped datui-pyo3 from pyo3 0.26 to 0.29.2, which is the patched release for both advisories I had suppressed:

- **RUSTSEC-2026-0176**, out-of-bounds read in `nth`/`nth_back` on `PyList` and `PyTuple` iterators
- **RUSTSEC-2026-0177**, missing `Sync` bound on `PyCFunction::new_closure`

The entries were correct when written. Neither API was reachable from this crate, checked against its source rather than assumed.

They are now not merely unnecessary but **actively harmful**. A suppression that outlives its reason silences the next occurrence too. If a future pyo3 regression reintroduced either advisory, cargo-deny would have said nothing, and the file would have looked like someone had considered it.

This is the discipline the file's own header asks for: every entry is a debt, and debts get paid off rather than accumulated.

Six remain, each with the event that clears it. The two worth watching are the quick-xml pair, which now reach us only through `object_store`'s S3 and GCS XML parsing and clear when polars bumps object_store.

Verified: `cargo deny check` clean on both lockfiles with the entries removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T3dG16ZsDzbMnN2yJtdYw4