### PR TITLE
Stop cancelling CI runs on main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,11 @@ on:
 # This kills redundant builds if you push multiple times to the same PR
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: true
+  # Cancel superseded runs on a pull request, never on main. Pushing twice to a
+  # branch should not build it twice; merging twice in quick succession leaves
+  # main with cancelled runs, and a cancelled run reads as a failed one on the
+  # README badge and in the branch history.
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 permissions:
   contents: read

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -28,7 +28,11 @@ permissions:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: true
+  # Cancel superseded runs on a pull request, never on main. Pushing twice to a
+  # branch should not build it twice; merging twice in quick succession leaves
+  # main with cancelled runs, and a cancelled run reads as a failed one on the
+  # README badge and in the branch history.
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   cargo-deny:


### PR DESCRIPTION
Merging three pull requests within a few seconds left main with two cancelled CI runs and one successful one, and the README badge briefly read as failing. Two of the last four runs on main were cancelled for this reason.

`cancel-in-progress: true` was applied to **every** event. That is right for a pull request, where pushing twice should not build twice. It is wrong for main, where every commit is one somebody may later need a verdict on.

A cancelled run is not a passing run. It reads as failure on the badge, and it leaves a commit whose CI result is simply **unknown**, which is worse than either answer. If you ever need to know whether a particular commit on main was green, a cancelled run cannot tell you.

Now conditional on the event being a pull request:

```yaml
cancel-in-progress: ${{ github.event_name == 'pull_request' }}
```

The grouping is unchanged, so pushes to a branch still supersede each other.

Applied to the Security workflow too, which had inherited the same line from CI when I wrote it.

Verified: all workflow files parse, and zizmor still reports nothing at high severity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T3dG16ZsDzbMnN2yJtdYw4