### PR TITLE
Publish SHA256SUMS with releases and verify them on install

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -496,6 +496,41 @@ jobs:
           echo "--- release body ---"
           cat "$out"
 
+      - name: Compute SHA256SUMS
+        # Everything a user can download gets a checksum, in the standard
+        # `sha256sum -c` format so no special tooling is needed to check one.
+        #
+        # This does not prove the artifacts came from datui: whoever could
+        # replace a release asset could replace this file alongside it. What it
+        # does give is integrity against a truncated or corrupted download, a
+        # stable value to compare against when a mirror or a package repository
+        # republishes a binary, and something for the installer to verify. A
+        # signature is the next step and a separate one.
+        run: |
+          shopt -s nullglob
+          mkdir -p release-assets
+          cp target/debian/*.deb \
+             target/generate-rpm/*.rpm \
+             target/cargo-aur/*.tar.gz \
+             target/cargo-aur/PKGBUILD \
+             python/dist/*.whl \
+             "windows-artifacts/datui-${REF_NAME}-windows-x86_64.zip" \
+             windows-artifacts/python/dist/*.whl \
+             macos-aarch64/datui-*.tar.gz \
+             macos-aarch64/python/dist/*.whl \
+             macos-x86_64/datui-*.tar.gz \
+             macos-x86_64/python/dist/*.whl \
+             release-assets/
+          cd release-assets
+          # Basenames only, so `sha256sum -c` works from whatever directory the
+          # user downloaded into.
+          sha256sum -- * > ../SHA256SUMS
+          cd ..
+          echo "--- SHA256SUMS ---"
+          cat SHA256SUMS
+        env:
+          REF_NAME: ${{ github.ref_name }}
+
       - name: Create GitHub Release
         # SHA-pinned to defend against upstream takeover; bump deliberately.
         uses: softprops/action-gh-release@efb35369e0ad2afab669f228072c1b0d510eae64 # v3.0.3
@@ -503,6 +538,7 @@ jobs:
           tag_name: ${{ github.ref_name }}
           body_path: ${{ steps.release_body.outputs.path }}
           files: |
+            SHA256SUMS
             target/debian/*.deb
             target/generate-rpm/*.rpm
             target/cargo-aur/*.tar.gz

--- a/scripts/install/install.sh
+++ b/scripts/install/install.sh
@@ -115,11 +115,59 @@ esac
 
 # --- Helper functions ---
 
+# Check a downloaded file against the release's SHA256SUMS.
+#
+# This catches a truncated or corrupted download, and a mirror serving something
+# other than what was released. It does not prove the file came from datui:
+# whoever could replace the asset could replace SHA256SUMS beside it. Signing is
+# the next step and a separate one.
+#
+# Releases before SHA256SUMS existed have no such file, and a missing one is not
+# treated as failure — otherwise this script stops working for older versions.
+# A checksum that is present and wrong always fails.
+verify_checksum() {
+    file="$1"
+    name="$2"
+
+    if command -v sha256sum > /dev/null 2>&1; then
+        sum_cmd="sha256sum"
+    elif command -v shasum > /dev/null 2>&1; then
+        sum_cmd="shasum -a 256"
+    else
+        echo "Note: no sha256sum or shasum found; skipping checksum verification."
+        return 0
+    fi
+
+    sums="$TMP_DIR/SHA256SUMS"
+    if ! curl -fsSL "$GITHUB_URL/SHA256SUMS" -o "$sums" 2> /dev/null; then
+        echo "Note: this release publishes no SHA256SUMS; skipping verification."
+        return 0
+    fi
+
+    expected=$(awk -v n="$name" '$2 == n || $2 == "*" n { print $1; exit }' "$sums")
+    if [ -z "$expected" ]; then
+        echo "Note: $name is not listed in SHA256SUMS; skipping verification."
+        return 0
+    fi
+
+    actual=$($sum_cmd "$file" | awk '{print $1}')
+    if [ "$actual" != "$expected" ]; then
+        echo "Checksum mismatch for $name."
+        echo "  expected: $expected"
+        echo "  actual:   $actual"
+        echo "Refusing to install. Try again, and report it if it persists:"
+        echo "  https://github.com/$REPO/security/advisories/new"
+        exit 1
+    fi
+    echo "Checksum OK."
+}
+
 download_tarball() {
     FILENAME="$1"
     TMP_DIR=$(mktemp -d)
     echo "Downloading $FILENAME... ($TMP_DIR)"
     curl -sSL "$GITHUB_URL/$FILENAME" -o "$TMP_DIR/$FILENAME"
+    verify_checksum "$TMP_DIR/$FILENAME" "$FILENAME"
 }
 
 install_tarball() {


### PR DESCRIPTION
Release binaries shipped with nothing to check them against, so the installer and anyone downloading by hand trusted HTTPS and GitHub alone. `SECURITY.md` said so plainly, which was honest but not a fix.

The release job now hashes every downloadable asset and attaches `SHA256SUMS` in the standard `sha256sum -c` format, so checking one by hand needs no special tooling. `install.sh` fetches it and verifies what it downloaded before installing.

## What this is and isn't

**It does not prove an artifact came from datui.** Whoever could replace a release asset could replace `SHA256SUMS` beside it.

What it does give:

- Integrity against a truncated or corrupted download.
- A fixed value to compare against when a mirror or a distro package republishes a binary.
- A published record that a later tampering attempt has to contradict.

A signature is the next step, and a separate one. Worth doing at some point; this is the cheap 80%.

## Failure behaviour

Verification is **skipped, not failed**, when a release predates `SHA256SUMS` or when the file is not listed. Otherwise this script would immediately stop working for every existing version.

A checksum that is present and does **not** match always fails, and the message points at the private reporting link rather than just erroring out.

Uses `sha256sum` or `shasum`, whichever exists, since macOS ships only the second.

## Verification

Tested against a stubbed download:

| Case | Result |
|---|---|
| Correct checksum | installs |
| Wrong checksum | exits 1, refuses to install |
| No SHA256SUMS published | note, continues |
| File not listed | note, continues |

The wrong-checksum case is the one that matters, and it was checked rather than assumed. `install.sh` also passes `sh -n`.

Note this cannot be fully exercised until the next release actually produces a `SHA256SUMS`, which will be the first run of this code path in anger.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T3dG16ZsDzbMnN2yJtdYw4
