### PR TITLE
Say that releases now publish checksums

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -36,5 +36,5 @@ Out of scope:
   tracked in `deny.toml`.
 - Anything needing an attacker who can already write to your home directory.
 
-Release binaries ship without checksums or signatures. Build from source if you
-want more than HTTPS and GitHub.
+Releases publish `SHA256SUMS`, and the install script checks it. There are no
+signatures yet, so a checksum proves the file arrived intact, not who built it.


### PR DESCRIPTION
#106 attaches `SHA256SUMS` to releases and has `install.sh` verify it, so the line saying binaries ship with nothing to check them against is no longer true.

Still says there are no signatures, because there are not, and a checksum proves a file arrived intact rather than who built it. That distinction is the only reason the sentence is worth keeping at all.

Two lines. `SECURITY.md` stays at 40.