### PR TITLE
Add brew trust to the Homebrew install steps

### DIFF
--- a/.github/workflows/test-install.yml
+++ b/.github/workflows/test-install.yml
@@ -38,6 +38,7 @@ jobs:
       - name: Homebrew tap install
         run: |
           brew tap derekwisong/datui
+          brew trust derekwisong/datui
           brew install datui
 
       - name: Verify Homebrew install

--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ Get the pre-built binary for your platform from the [Latest Release](https://git
 - **macOS (Homebrew)**:
   ```bash
   brew tap derekwisong/datui
+  brew trust derekwisong/datui
   brew install datui
   ```
 - **Windows (WinGet)**:

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -24,8 +24,11 @@ Install via the [derekwisong/datui](https://github.com/derekwisong/homebrew-datu
 
 ```bash
 brew tap derekwisong/datui
+brew trust derekwisong/datui
 brew install datui
 ```
+
+Homebrew requires `brew trust` before it will install from a third-party tap.
 
 ### Windows (WinGet)
 


### PR DESCRIPTION
Homebrew refuses to install from a third-party tap without `brew trust`:

```
Refusing to load formula derekwisong/datui/datui from untrusted tap derekwisong/datui.
```

The documented Homebrew install currently fails for anyone following it. Added the command to the README, the install guide, and the Test Install workflow, where both macOS jobs failed on this.

The one-line install is unaffected. It passed on all six platforms in the same run.