### PR TITLE
Let an answered home-screen probe give its slot back

### DIFF
--- a/crates/datui-lib/src/lib.rs
+++ b/crates/datui-lib/src/lib.rs
@@ -166,6 +166,66 @@ mod export_format_tests {
 }
 
 #[cfg(test)]
+mod probe_slot_tests {
+    use super::*;
+    use std::sync::mpsc;
+
+    /// A probe that answers must give its slot back. The cap is there to bound threads
+    /// wedged on a dead mount, and those never answer at all; counting completed probes
+    /// against it meant that after MAX_CONCURRENT_PROBES roots, no root was ever probed
+    /// again for the rest of the session. Roots accumulate as datasets are opened on
+    /// different mounts, so this is reached by ordinary use, and it shows as a network
+    /// section that stays empty with no error.
+    #[test]
+    fn an_answered_probe_frees_its_slot() {
+        let (tx, _rx) = mpsc::channel();
+        let mut app = App::new(tx, crate::tests::test_runtime());
+
+        let roots: Vec<PathBuf> = (0..MAX_CONCURRENT_PROBES)
+            .map(|i| PathBuf::from(format!("/pretend/remote{i}")))
+            .collect();
+        app.home_probes_inflight = roots.clone();
+
+        for (i, root) in roots.iter().enumerate() {
+            // Alternate the two ways a probe can answer; both are answers.
+            let rows = if i % 2 == 0 { Some(Vec::new()) } else { None };
+            app.event(&AppEvent::HomeProbeReady {
+                root: root.clone(),
+                rows,
+            });
+        }
+
+        assert!(
+            app.home_probes_inflight.is_empty(),
+            "every probe answered, so nothing should still hold a slot: {:?}",
+            app.home_probes_inflight
+        );
+    }
+
+    /// A root that never answers keeps its slot, which is the whole point of the cap.
+    #[test]
+    fn an_unanswered_probe_keeps_its_slot() {
+        let (tx, _rx) = mpsc::channel();
+        let mut app = App::new(tx, crate::tests::test_runtime());
+
+        let wedged = PathBuf::from("/pretend/dead-mount");
+        let answered = PathBuf::from("/pretend/live-mount");
+        app.home_probes_inflight = vec![wedged.clone(), answered.clone()];
+
+        app.event(&AppEvent::HomeProbeReady {
+            root: answered,
+            rows: Some(Vec::new()),
+        });
+
+        assert_eq!(
+            app.home_probes_inflight,
+            vec![wedged],
+            "a thread still stuck on a dead mount must keep costing a slot"
+        );
+    }
+}
+
+#[cfg(test)]
 pub mod tests {
     use std::path::Path;
     use std::process::Command;
@@ -7510,6 +7570,12 @@ impl App {
                 None
             }
             AppEvent::HomeProbeReady { root, rows } => {
+                // Give the slot back. The cap exists to bound threads wedged on a dead
+                // `hard` mount, which never send this event and so keep their slot for
+                // good — a probe that answered is not one of those. Without this the
+                // list only grows, and after MAX_CONCURRENT_PROBES roots no further
+                // root is ever probed for the rest of the session.
+                self.home_probes_inflight.retain(|p| p != root);
                 match rows {
                     Some(rows) => self.home.probe_ready(root.clone(), rows.clone()),
                     None => self.home.probe_failed(root.clone()),


### PR DESCRIPTION
Remote roots on the home screen are listed by a detached probe thread, capped at four concurrent. The cap is deliberate: a probe of a dead `hard` mount costs a thread that never returns, so a machine with a page of stale mounts must not spawn one per mount.

The in-flight list was only ever appended to. A probe that answered stayed on it for good, so the cap counted completed work as though it were wedged. After four roots, no root was ever probed again for the rest of the session.

## Why this is reachable in ordinary use

Nothing here needs bad luck or an unusual setup. Opening a dataset on a mount makes that mount a root from then on, so roots accumulate as you work across several network locations. The fifth one shows as a network section that simply stays empty: no error, no spinner, nothing to suggest a probe was ever meant to happen.

Below four network roots the bug is invisible, which is presumably why it has gone unnoticed. A completed root also lands in the probed or unreachable set, and the function that picks what to probe skips those, so the stale entry never causes a duplicate probe. It only ever causes a missing one.

## The fix

Drop the root from the list when its result arrives, next to where that result is recorded. A thread still stuck on a dead mount never sends this event, so it keeps its slot, which is what the cap was always for.

Two tests: one that four answered probes leave nothing holding a slot, covering both ways a probe can answer, and one that an unanswered probe still costs a slot so the cap keeps doing its job. Both fail without the change.

## Not addressed here

A root that was found unreachable stays unreachable for the whole session. Bring the share back up and datui keeps it greyed out until restart. Retrying on an explicit refresh would be a real improvement, but that is a behaviour decision rather than a bug, and `notes/datui-as-a-place.md` only settled that an unreachable root should be shown, not when to re-check it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UxmdPPm5G53io6YZgTmp4w