### PR TITLE
Ignore Claude Code worktrees

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,6 @@ python/datui/datui_bin/
 
 # Generated winget manifests (from scripts/winget/generate_manifests.sh)
 scripts/winget/out/
+
+# Claude Code worktrees
+.claude/worktrees/


### PR DESCRIPTION
Claude Code creates scratch worktrees under `.claude/worktrees/`. It also appends a matching rule to `.git/info/exclude`, but that file is local to a single clone, so the ignore does not travel with the repo.

This adds the rule to the tracked `.gitignore` so any clone is covered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GxZJAxcj1HP7nCYXEn67L4