### PR TITLE
Show the load, not the dataset it is replacing

### DIFF
--- a/crates/datui-lib/src/glyphs.rs
+++ b/crates/datui-lib/src/glyphs.rs
@@ -38,6 +38,9 @@ pub struct Glyphs {
     pub updown: &'static str,
     /// Left/right pair, for the fold hint.
     pub updown_lr: &'static str,
+    /// Spinner frames, cycled while something is loading. Every frame must be the
+    /// same display width, or the text beside it jitters.
+    pub spinner: &'static [&'static str],
 }
 
 const UNICODE: Glyphs = Glyphs {
@@ -52,6 +55,7 @@ const UNICODE: Glyphs = Glyphs {
     expanded: "▾ ",
     updown: "↑↓",
     updown_lr: "←→",
+    spinner: &["⣷", "⣯", "⣟", "⡿", "⢿", "⣻", "⣽", "⣾"],
 };
 
 const ASCII: Glyphs = Glyphs {
@@ -66,6 +70,7 @@ const ASCII: Glyphs = Glyphs {
     expanded: "- ",
     updown: "Up/Dn",
     updown_lr: "Lt/Rt",
+    spinner: &["|", "/", "-", "\\"],
 };
 
 /// What the user asked for, from `[display] unicode`.

--- a/crates/datui-lib/src/lib.rs
+++ b/crates/datui-lib/src/lib.rs
@@ -1273,6 +1273,14 @@ pub struct App {
     /// check this and bail. Deliberately separate from `task_generation`, which also
     /// gates analysis and export results — going home must not cancel an export.
     load_active: bool,
+    /// True from the moment a load starts until it installs its dataset, fails, or is
+    /// abandoned. While it is set, whatever `data_table_state` holds belongs to the
+    /// *previous* dataset, so the main view shows the load's progress instead of it —
+    /// otherwise the old table sits under the new file's name for the whole load.
+    ///
+    /// Separate from `load_active`, which stays set through the buffer collect that
+    /// follows installation: by then the table on screen is the right one.
+    awaiting_dataset: bool,
     /// LazyFrame produced by a background scan, tagged with the generation that
     /// asked for it. Mirrors `pending_schema_result`; a stale entry is discarded.
     pending_lazyframe_result: Arc<Mutex<Option<(u64, LazyFrame)>>>,
@@ -1335,6 +1343,10 @@ impl App {
     /// loading UI immediately when launching from LazyFrame (e.g. Python) before sending the open event.
     pub fn set_loading_phase(&mut self, phase: impl Into<String>, progress_percent: u16) {
         self.busy = true;
+        // A frame is drawn between the keypress that starts a load and the `Open` that
+        // carries it out, so the handover has to happen here too or that frame still
+        // shows the outgoing dataset.
+        self.awaiting_dataset = true;
         self.loading_state = LoadingState::Loading {
             file_path: None,
             file_size: 0,
@@ -1359,6 +1371,7 @@ impl App {
             "apply_schema_ready called for an abandoned load"
         );
         self.debug.schema_load = debug_label;
+        self.awaiting_dataset = false;
         self.parquet_metadata_cache = None;
         self.export_df = None;
         self.data_table_state = Some(state);
@@ -1730,6 +1743,7 @@ impl App {
             runtime,
             task_generation: 0,
             load_active: false,
+            awaiting_dataset: false,
             pending_lazyframe_result: Arc::new(Mutex::new(None)),
             pending_schema_result: std::sync::Arc::new(std::sync::Mutex::new(None)),
             len_count_inflight: None,
@@ -2011,6 +2025,9 @@ impl App {
     /// must survive this.
     pub fn abandon_load(&mut self) {
         self.load_active = false;
+        // Nothing is arriving to replace it, so the dataset already on screen is the
+        // current one again — Esc from home goes straight back to it.
+        self.awaiting_dataset = false;
         #[cfg(any(feature = "http", feature = "cloud"))]
         if self.pending_download.take().is_some() {
             self.confirmation_modal.hide();
@@ -2176,6 +2193,13 @@ impl App {
         }
         self.input_mode = InputMode::Normal;
         self.set_loading_phase("Scanning input", 10);
+        // A frame is drawn between this keypress and the `Open` that carries it out,
+        // and it is the one the user is looking at when they press Enter — so it says
+        // which file, not just that something is happening. `Open` fills in the size a
+        // frame later; stat'ing here would put a possibly-dead mount on this thread.
+        if let LoadingState::Loading { file_path, .. } = &mut self.loading_state {
+            *file_path = Some(path.clone());
+        }
         self.busy = true;
         AppEvent::Open(vec![path], options)
     }
@@ -7301,6 +7325,7 @@ impl App {
                 }
                 self.task_generation = self.task_generation.wrapping_add(1);
                 self.load_active = true;
+                self.awaiting_dataset = true;
                 self.busy = true;
                 let first = &paths[0];
                 // Every open records a recent, not just those started from the home
@@ -7345,6 +7370,7 @@ impl App {
             AppEvent::OpenLazyFrame(lf, options) => {
                 self.task_generation = self.task_generation.wrapping_add(1);
                 self.load_active = true;
+                self.awaiting_dataset = true;
                 self.busy = true;
                 self.loading_state = LoadingState::Loading {
                     file_path: None,
@@ -8159,6 +8185,7 @@ impl App {
                         }
                     }
                     // Generation matched but slot was empty or stale — loading failed silently.
+                    self.awaiting_dataset = false;
                     self.loading_state = LoadingState::Idle;
                     self.status_message = None;
                     self.busy = false;
@@ -8269,6 +8296,9 @@ impl App {
             } => {
                 if *generation == self.task_generation {
                     self.analysis_modal.computing = None;
+                    // The load is over and installed nothing, so the previous dataset is
+                    // the current one again — and it is what the error modal sits over.
+                    self.awaiting_dataset = false;
                     self.loading_state = LoadingState::Idle;
                     self.status_message = None;
                     self.busy = false;
@@ -9374,16 +9404,7 @@ impl Widget for &mut App {
             self.number_format.clone(),
         );
 
-        // Must match the dispatch in `render_main_view`: home takes precedence, so the
-        // control bar shows home's keys rather than the table's.
-        let main_view_content = if self.input_mode == InputMode::Home {
-            MainViewContent::Home
-        } else {
-            MainViewContent::from_app_state(
-                self.analysis_modal.active,
-                self.input_mode == InputMode::Chart,
-            )
-        };
+        let main_view_content = MainViewContent::current(self);
 
         Clear.render(area, buf);
         let background_color = self.color("background");
@@ -9531,7 +9552,10 @@ impl Widget for &mut App {
         //  - in flight   -> spinner (still being computed)
         //  - failed       -> "?" (computation gave up; don't show a misleading partial total)
         //  - otherwise    -> the number
-        let count_pending = self.len_count_inflight.is_some();
+        // A load in flight counts as pending: the number `data_table_state` still holds
+        // belongs to the dataset being replaced, and printing it beside the incoming
+        // file's name would read as the new one's.
+        let count_pending = self.len_count_inflight.is_some() || self.awaiting_dataset;
         let count_unknown = !count_pending
             && self.data_table_state.as_ref().is_some_and(|s| {
                 !s.is_num_rows_valid() && self.len_count_failed == Some(s.len_generation())

--- a/crates/datui-lib/src/render/datatable_main.rs
+++ b/crates/datui-lib/src/render/datatable_main.rs
@@ -152,7 +152,9 @@ pub fn render(
             }
         }
         None => {
-            // Show nothing while loading — the status bar spinner communicates progress.
+            // No dataset at all: a first load that failed, leaving its error modal over
+            // an empty screen. A load still in flight never reaches here — it draws
+            // `loading_view` instead.
         }
     }
 

--- a/crates/datui-lib/src/render/loading_view.rs
+++ b/crates/datui-lib/src/render/loading_view.rs
@@ -1,0 +1,172 @@
+//! The main view while a dataset is on its way in.
+//!
+//! It stands in for the table from the moment a load starts until that load installs
+//! its dataset. Without it the previous dataset stayed on screen for the whole load —
+//! one file's rows under another file's name, with only the control bar to say so.
+//!
+//! Drawn in the same family as the home screen: no boxes, centred, one accent. The
+//! phase name is the progress indicator. It is a real, observable step ("Scanning
+//! input", "Caching schema", "Loading buffer"), unlike the percentage beside it in
+//! the control bar, which is a constant per phase.
+
+use crate::glyphs;
+use crate::render::context::RenderContext;
+use crate::LoadingState;
+use ratatui::buffer::Buffer;
+use ratatui::layout::Rect;
+use ratatui::style::{Modifier, Style};
+use ratatui::text::{Line, Span};
+use ratatui::widgets::{Clear, Paragraph, Widget};
+
+pub fn render(area: Rect, buf: &mut Buffer, app: &crate::App, ctx: &RenderContext) {
+    Clear.render(area, buf);
+    if area.width < 12 || area.height < 3 {
+        return;
+    }
+
+    let (phase, path, size) = match &app.loading_state {
+        LoadingState::Loading {
+            current_phase,
+            file_path,
+            file_size,
+            ..
+        } => (current_phase.as_str(), file_path.clone(), *file_size),
+        // A load with no phase of its own yet — the frame between the keypress and
+        // the event that carries it out.
+        _ => ("Loading", None, 0),
+    };
+
+    let g = glyphs::get();
+    let frame = app.throbber_frame as usize % g.spinner.len();
+    let mut lines = vec![
+        Line::from(vec![
+            Span::styled(
+                format!("{}  ", g.spinner[frame]),
+                Style::default().fg(ctx.throbber),
+            ),
+            Span::styled(
+                format!("{phase}{}", g.ellipsis),
+                Style::default()
+                    .fg(ctx.text_primary)
+                    .add_modifier(Modifier::BOLD),
+            ),
+        ]),
+        Line::from(""),
+    ];
+
+    // The name first and the location under it: which file is coming is the question
+    // being answered, and a long path would push the name off a narrow screen.
+    if let Some(path) = path.as_ref() {
+        let name = path
+            .file_name()
+            .map(|n| n.to_string_lossy().into_owned())
+            .unwrap_or_else(|| crate::home::display_path(path));
+        lines.push(Line::from(Span::styled(
+            truncate(&name, area.width as usize),
+            Style::default().fg(ctx.text_primary),
+        )));
+        let mut detail = crate::home::display_path(path);
+        if size > 0 {
+            detail = format!("{detail}   {}", crate::discover::format_size(size));
+        }
+        lines.push(Line::from(Span::styled(
+            truncate_start(&detail, area.width as usize),
+            Style::default().fg(ctx.text_secondary),
+        )));
+    }
+
+    // Centred vertically, a little above the middle: text sitting dead centre in a
+    // tall terminal reads as low.
+    let top = area
+        .y
+        .saturating_add(area.height.saturating_sub(lines.len() as u16) / 2)
+        .saturating_sub(1)
+        .max(area.y);
+    let height = (lines.len() as u16).min(area.height.saturating_sub(top - area.y));
+    let body = Rect {
+        x: area.x,
+        y: top,
+        width: area.width,
+        height,
+    };
+    Paragraph::new(lines).centered().render(body, buf);
+}
+
+/// Keep the head of a string, marking what was cut.
+fn truncate(text: &str, width: usize) -> String {
+    if text.chars().count() <= width {
+        return text.to_string();
+    }
+    let g = glyphs::get();
+    let keep = width.saturating_sub(g.ellipsis.chars().count());
+    text.chars().take(keep).collect::<String>() + g.ellipsis
+}
+
+/// Keep the tail of a path; the leaf is what says where the file is.
+fn truncate_start(text: &str, width: usize) -> String {
+    let count = text.chars().count();
+    if count <= width {
+        return text.to_string();
+    }
+    let g = glyphs::get();
+    let keep = width.saturating_sub(g.ellipsis.chars().count());
+    let skip = count.saturating_sub(keep);
+    g.ellipsis.to_string() + &text.chars().skip(skip).collect::<String>()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn cells(buf: &Buffer) -> String {
+        buf.content().iter().map(|c| c.symbol()).collect()
+    }
+
+    #[test]
+    fn a_load_with_no_room_to_draw_is_skipped_rather_than_panicking() {
+        // Terminals get resized to absurd sizes mid-load, and a load is exactly when
+        // the user cannot press anything to recover.
+        let (tx, _rx) = std::sync::mpsc::channel();
+        let mut app = crate::App::new(tx, test_runtime());
+        app.set_loading_phase("Scanning input", 10);
+        for (w, h) in [(1, 1), (4, 2), (11, 40), (200, 1)] {
+            let area = Rect::new(0, 0, w, h);
+            let mut buf = Buffer::empty(area);
+            render(area, &mut buf, &app, &RenderContext::for_test());
+        }
+    }
+
+    #[test]
+    fn the_phase_and_the_file_are_both_on_screen() {
+        let (tx, _rx) = std::sync::mpsc::channel();
+        let mut app = crate::App::new(tx, test_runtime());
+        app.loading_state = LoadingState::Loading {
+            file_path: Some(std::path::PathBuf::from("/tmp/quarterly.parquet")),
+            file_size: 2048,
+            current_phase: "Caching schema".to_string(),
+            progress_percent: 40,
+        };
+
+        let area = Rect::new(0, 0, 60, 20);
+        let mut buf = Buffer::empty(area);
+        render(area, &mut buf, &app, &RenderContext::for_test());
+
+        let text = cells(&buf);
+        assert!(text.contains("Caching schema"), "phase missing: {text:?}");
+        assert!(text.contains("quarterly.parquet"), "file missing: {text:?}");
+        assert!(text.contains("2.0 KB"), "size missing: {text:?}");
+    }
+
+    fn test_runtime() -> tokio::runtime::Handle {
+        static RT: std::sync::OnceLock<tokio::runtime::Runtime> = std::sync::OnceLock::new();
+        RT.get_or_init(|| {
+            tokio::runtime::Builder::new_multi_thread()
+                .worker_threads(1)
+                .enable_all()
+                .build()
+                .expect("test runtime")
+        })
+        .handle()
+        .clone()
+    }
+}

--- a/crates/datui-lib/src/render/main_view.rs
+++ b/crates/datui-lib/src/render/main_view.rs
@@ -9,9 +9,31 @@ pub enum MainViewContent {
     Chart,
     /// Full-screen home screen: pick a dataset.
     Home,
+    /// Full-screen progress for a dataset that is still loading. Whatever table state
+    /// exists belongs to the dataset being replaced, so none of it is shown.
+    Loading,
 }
 
 impl MainViewContent {
+    /// Which view is showing. The one place that decides, so the main area and the
+    /// control bar at the foot of it cannot disagree about what the user is looking at.
+    ///
+    /// Home first: it is where you are, not an overlay. Then a load in flight, which
+    /// owns the screen until it has a dataset to hand over — every other view would be
+    /// drawing the dataset it is replacing.
+    pub fn current(app: &crate::App) -> Self {
+        if app.input_mode == crate::InputMode::Home {
+            MainViewContent::Home
+        } else if app.awaiting_dataset {
+            MainViewContent::Loading
+        } else {
+            MainViewContent::from_app_state(
+                app.analysis_modal.active,
+                app.input_mode == crate::InputMode::Chart,
+            )
+        }
+    }
+
     /// Determine active main-view content from app state.
     pub fn from_app_state(analysis_active: bool, input_mode_chart: bool) -> Self {
         if analysis_active {
@@ -73,6 +95,11 @@ pub fn control_bar_spec(app: &crate::App, content: MainViewContent) -> ControlBa
             ControlBarSpec::Custom(pairs)
         }
         MainViewContent::Chart => ControlBarSpec::Custom(vec![("Esc", "Back"), ("e", "Export")]),
+        // Only the keys that survive the busy gate in `App::key`. Offering anything
+        // else would be advertising something that does nothing.
+        MainViewContent::Loading => {
+            ControlBarSpec::Custom(vec![("^O", "Home"), ("?", "Help"), ("q", "Quit")])
+        }
         MainViewContent::Home => ControlBarSpec::Custom(home_control_keys(
             app.home.path_input_active,
             app.home.browsing.is_some(),

--- a/crates/datui-lib/src/render/main_view_render.rs
+++ b/crates/datui-lib/src/render/main_view_render.rs
@@ -1,8 +1,8 @@
-//! Main view dispatcher: datatable, analysis, or chart.
+//! Main view dispatcher: home, loading, datatable, analysis, or chart.
 
 use crate::render::main_view::MainViewContent;
 
-/// Renders the main view based on content mode: datatable (table + sidebars), analysis, or chart.
+/// Renders whichever view [`MainViewContent::current`] says is showing.
 pub fn render_main_view(
     area: ratatui::layout::Rect,
     main_area: ratatui::layout::Rect,
@@ -10,15 +10,7 @@ pub fn render_main_view(
     app: &mut crate::App,
     ctx: &crate::render::context::RenderContext,
 ) {
-    // Home takes precedence over everything: it is where you are, not an overlay.
-    let content = if app.input_mode == crate::InputMode::Home {
-        MainViewContent::Home
-    } else {
-        MainViewContent::from_app_state(
-            app.analysis_modal.active,
-            app.input_mode == crate::InputMode::Chart,
-        )
-    };
+    let content = MainViewContent::current(app);
     match content {
         MainViewContent::Datatable => {
             crate::render::datatable_main::render(area, main_area, buf, app, ctx);
@@ -31,6 +23,9 @@ pub fn render_main_view(
         }
         MainViewContent::Home => {
             crate::render::home_view::render(main_area, buf, app, ctx);
+        }
+        MainViewContent::Loading => {
+            crate::render::loading_view::render(main_area, buf, app, ctx);
         }
     }
 }

--- a/crates/datui-lib/src/render/mod.rs
+++ b/crates/datui-lib/src/render/mod.rs
@@ -6,6 +6,7 @@ pub mod datatable_view;
 pub mod home_view;
 pub mod input_strip;
 pub mod layout;
+pub mod loading_view;
 pub mod main_view;
 pub mod main_view_render;
 pub mod overlays;

--- a/docs/user-guide/home-screen.md
+++ b/docs/user-guide/home-screen.md
@@ -272,6 +272,23 @@ the order currently in effect where the cursor is:
 Rows with nothing to sort by go last rather than counting as zero, so `size` does not
 open with a page of datasets whose size has not been read yet.
 
+## While a dataset is loading
+
+Pressing <kbd>Enter</kbd> leaves this screen immediately, and what replaces it is the
+load in progress, not the dataset you had open before:
+
+```
+                            ⣷  Caching schema…
+
+                              events.parquet
+                       ~/data/events.parquet   120 MB
+```
+
+The phase names a real step — scanning the input, caching the schema, filling the
+first buffer — so a load that is slow still shows where it has got to.
+<kbd>Ctrl</kbd>+<kbd>O</kbd> abandons it and comes back here; <kbd>Esc</kbd> from here
+then returns you to whatever was open before, which is untouched.
+
 ## When a dataset will not open
 
 datui shows what went wrong and returns you to this screen with the reason, so the

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -887,6 +887,27 @@ fn ctrl_o() -> AppEvent {
     AppEvent::Key(KeyEvent::new(KeyCode::Char('o'), KeyModifiers::CONTROL))
 }
 
+fn key(code: KeyCode) -> AppEvent {
+    AppEvent::Key(KeyEvent::new(code, KeyModifiers::NONE))
+}
+
+/// Every glyph in the buffer, in row order — enough to ask whether some text is on
+/// screen, which is all these tests need.
+fn rendered_text(buf: &Buffer) -> String {
+    buf.content().iter().map(|cell| cell.symbol()).collect()
+}
+
+/// The same, without the control bar on the last row. The bar reports a load on its
+/// own; assertions about what the *view* shows have to exclude it.
+fn main_area_text(buf: &Buffer, area: Rect) -> String {
+    let cells = (area.width as usize) * (area.height as usize - 1);
+    buf.content()
+        .iter()
+        .take(cells)
+        .map(|cell| cell.symbol())
+        .collect()
+}
+
 /// Ctrl+O at any point during a load must abandon it: whatever is on screen when the
 /// user goes home is what is still there afterwards. The load runs to completion in
 /// the background and its results are dropped.
@@ -1290,5 +1311,110 @@ fn test_error_modal_over_home_is_dismissable() {
     assert!(
         matches!(out, Some(AppEvent::Exit)),
         "once the modal is dismissed Esc should behave as home's Esc again"
+    );
+}
+
+/// Opening a second dataset from the home screen must not show the first one's rows
+/// while the second is still loading. Between the keypress and the new dataset being
+/// installed, the old table was still on screen — a page of one file's data under the
+/// filename of another, for as long as the load took.
+#[test]
+fn test_opening_from_home_does_not_show_the_previous_dataset() {
+    common::ensure_sample_data();
+    let first = PathBuf::from("tests/sample-data/people.parquet");
+    let second = PathBuf::from("tests/sample-data/large_dataset.parquet");
+
+    let area = Rect::new(0, 0, 120, 50);
+    let (tx, rx) = mpsc::channel();
+    let mut app = App::new(tx.clone(), common::test_runtime());
+    tx.send(AppEvent::Open(vec![first.clone()], OpenOptions::default()))
+        .unwrap();
+
+    for _tick in 0..200 {
+        drain_like_main_loop(&mut app, &tx, &rx);
+        let mut buf = Buffer::empty(area);
+        app.render(area, &mut buf);
+        let needs = app
+            .data_table_state
+            .as_mut()
+            .map(|s| {
+                let n = s.needs_recollect;
+                s.needs_recollect = false;
+                n
+            })
+            .unwrap_or(false);
+        if needs {
+            app.spawn_async_collect("Loading buffer...");
+        }
+        if app.data_table_state.is_some() && !app.is_busy() && !needs {
+            break;
+        }
+        std::thread::sleep(std::time::Duration::from_millis(5));
+    }
+    let mut buf = Buffer::empty(area);
+    app.render(area, &mut buf);
+    assert!(
+        rendered_text(&buf).contains("first_name"),
+        "the first dataset should be on screen before we go home"
+    );
+
+    // Home, then open the second dataset the way a user does: through the path
+    // prompt, so the real key path runs rather than a synthesised event.
+    app.event(&ctrl_o());
+    assert_eq!(app.input_mode, InputMode::Home);
+    app.event(&key(KeyCode::Char('~')));
+    for c in second.to_str().unwrap().chars() {
+        app.event(&key(KeyCode::Char(c)));
+    }
+    if let Some(next) = app.event(&key(KeyCode::Enter)) {
+        tx.send(next).unwrap();
+    }
+    assert_eq!(
+        app.input_mode,
+        InputMode::Normal,
+        "opening from home should leave the home screen"
+    );
+
+    // Every frame from here until the second dataset is installed.
+    let mut frames = 0usize;
+    for _tick in 0..200 {
+        drain_like_main_loop(&mut app, &tx, &rx);
+        let mut buf = Buffer::empty(area);
+        app.render(area, &mut buf);
+        frames += 1;
+        let text = main_area_text(&buf, area);
+        assert!(
+            !text.contains("first_name") && !text.contains("job_title"),
+            "frame {frames} showed the previous dataset while the next one was loading"
+        );
+        assert!(
+            text.contains("large_dataset.parquet") || text.contains("dist_normal"),
+            "frame {frames} named neither the dataset being loaded nor the one that arrived"
+        );
+        let needs = app
+            .data_table_state
+            .as_mut()
+            .map(|s| {
+                let n = s.needs_recollect;
+                s.needs_recollect = false;
+                n
+            })
+            .unwrap_or(false);
+        if needs {
+            app.spawn_async_collect("Loading buffer...");
+        }
+        if app.open_path() == Some(second.as_path()) && !app.is_busy() && !needs {
+            break;
+        }
+        std::thread::sleep(std::time::Duration::from_millis(5));
+    }
+    assert_eq!(
+        app.open_path(),
+        Some(second.as_path()),
+        "the second dataset should have loaded"
+    );
+    assert!(
+        frames > 1,
+        "the load finished in one frame; nothing was tested"
     );
 }


### PR DESCRIPTION
Opening a second dataset left the first one on screen for the whole load. The home screen hands back an open event and switches to the table view, but nothing clears `data_table_state` until the incoming schema is built, so the table drew the outgoing dataset under the incoming file's name, with its row count in the control bar beside it. On anything slower than a local Parquet that is seconds of one file's data presented as another's; on a fast one it is the flicker that prompted this.

A load now owns the screen from the keypress until it installs its dataset.

## The flag

`awaiting_dataset` is set where a load starts and cleared on each of the three ways one ends: the dataset is installed, the load fails, or the user abandons it with Ctrl+O.

That last one is why this is a flag rather than clearing `data_table_state` at the start of a load — abandoning has to put the previous dataset back untouched, and `test_escape_from_home_returns_to_the_dataset_that_was_open` says so. It is also separate from `load_active`, which stays set through the buffer collect that follows installation, by which point the table on screen is the right one.

## What is drawn instead

```
                            ⣷  Caching schema…

                           large_dataset.parquet
                  tests/sample-data/large_dataset.parquet   71.4 MB
```

Drawn in the home screen's family: no boxes, centred, one accent. The phase is the progress indicator because it is a real step — scanning the input, caching the schema, filling the first buffer — unlike the percentage in the control bar, which is a constant per phase. The control bar shows a spinner where the row count goes, rather than the count belonging to the dataset being replaced.

Opening from the home screen also names the file before the `Open` event is handled. A frame is drawn between the two, and it is the one the user is looking at when they press Enter.

## Along the way

Which view is showing now has one home, `MainViewContent::current`. It was duplicated between the render dispatcher and the control bar, with a comment asking the two to be kept in agreement — which adding a third view would have made easier to get wrong.

## Verification

- `test_opening_from_home_does_not_show_the_previous_dataset` opens one dataset, goes home, opens another through the path prompt, and checks every frame in between for a column of the outgoing dataset. It fails on frame 1 without the change.
- Two unit tests in `loading_view`: absurd terminal sizes mid-load, and the phase and file both reaching the screen.
- The release binary driven under vhs, to see the real screens rather than a buffer.
- `cargo test --workspace`, `cargo fmt --check` and `cargo clippy --all-targets` are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WUxebnz8wU72Z5fBgotx5X
