### PR TITLE
Sign releases, and audit the lockfile fuzzing added

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -365,3 +365,32 @@ jobs:
 
       - name: Run Python tests
         run: . .venv/bin/activate && pytest python/tests/ -v
+
+  # One context for the branch ruleset to require. The jobs above cannot be required
+  # directly: windows and macos are skipped on a -dev version, and a required check
+  # that never reports blocks the pull request forever rather than failing it. This
+  # job always runs, so it always reports, and it fails if anything it waits on
+  # failed or was cancelled. Skipped is not a failure -- that is the conditional
+  # platforms doing exactly what they were told.
+  #
+  # Note this gates the CI workflow only. A job cannot wait on another workflow's
+  # jobs, so Security's contexts (cargo-deny, zizmor) are required separately.
+  ci-passed:
+    name: CI passed
+    runs-on: ubuntu-latest
+    needs: [check, fuzz, linux, windows, macos]
+    if: always()
+    steps:
+      - name: Check that every job passed or was skipped
+        # Through env, not interpolated into the script: every expansion in a `run:`
+        # block is one zizmor flags, and the habit is worth more than the exception.
+        env:
+          RESULTS: ${{ join(needs.*.result, ' ') }}
+        run: |
+          echo "Job results: $RESULTS"
+          for result in $RESULTS; do
+            case "$result" in
+              success|skipped) ;;
+              *) echo "::error::A CI job reported '$result'"; exit 1 ;;
+            esac
+          done

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -504,8 +504,10 @@ jobs:
         # replace a release asset could replace this file alongside it. What it
         # does give is integrity against a truncated or corrupted download, a
         # stable value to compare against when a mirror or a package repository
-        # republishes a binary, and something for the installer to verify. A
-        # signature is the next step and a separate one.
+        # republishes a binary, and something for the installer to verify.
+        #
+        # The signature that does prove origin is applied to this file below, which is
+        # why signing one file is enough to cover every artifact listed in it.
         run: |
           shopt -s nullglob
           mkdir -p release-assets
@@ -531,6 +533,27 @@ jobs:
         env:
           REF_NAME: ${{ github.ref_name }}
 
+      - name: Install cosign
+        # SHA-pinned to defend against upstream takeover; bump deliberately.
+        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
+
+      - name: Sign SHA256SUMS
+        # Signing the checksum file rather than each artifact is deliberate: it already
+        # covers every downloadable by hash, so one signature carries the whole release,
+        # and there is one thing for a user to verify rather than a dozen.
+        #
+        # Keyless, via Sigstore. There is no private key here to store as a secret, to
+        # protect, to rotate, or to lose; the signing identity is this workflow's own
+        # OIDC token, which is why the job needs `id-token: write` (it already has it,
+        # for Pages). The signature therefore attests that this repository's release
+        # workflow produced the file at this tag, which is a stronger and more checkable
+        # claim than "someone holding a key did".
+        #
+        # The certificate is recorded in Rekor, Sigstore's public transparency log. That
+        # is public information about a public release, and it is what lets anyone verify
+        # without trusting us to serve them the right key.
+        run: cosign sign-blob --yes --bundle SHA256SUMS.sigstore.json SHA256SUMS
+
       - name: Create GitHub Release
         # SHA-pinned to defend against upstream takeover; bump deliberately.
         uses: softprops/action-gh-release@efb35369e0ad2afab669f228072c1b0d510eae64 # v3.0.3
@@ -539,6 +562,7 @@ jobs:
           body_path: ${{ steps.release_body.outputs.path }}
           files: |
             SHA256SUMS
+            SHA256SUMS.sigstore.json
             target/debian/*.deb
             target/generate-rpm/*.rpm
             target/cargo-aur/*.tar.gz

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -68,6 +68,16 @@ jobs:
           manifest-path: crates/datui-pyo3/Cargo.toml
           command: check ${{ matrix.checks }}
 
+      # fuzz/ is its own workspace for the same reason, with its own lockfile the
+      # check above does not see. Nothing in it ships in a binary, but it is a
+      # lockfile committed to this repository and an advisory in it still matters
+      # to anyone running the fuzzers.
+      - name: Check fuzz
+        uses: EmbarkStudios/cargo-deny-action@3c6349835b2b7b196a839186cb8b78e02f7b5f25 # v2.1.1
+        with:
+          manifest-path: fuzz/Cargo.toml
+          command: check ${{ matrix.checks }}
+
   zizmor:
     name: zizmor (workflow analysis)
     runs-on: ubuntu-latest

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -46,5 +46,36 @@ fuzzes for new findings. See
 [Fuzzing](https://derekwisong.github.io/datui/latest/for-developers/fuzzing.html) for how to
 run them, and `fuzz/` for the targets.
 
-Releases publish `SHA256SUMS`, and the install script checks it. There are no
-signatures yet, so a checksum proves the file arrived intact, not who built it.
+## Verifying a release
+
+Releases publish `SHA256SUMS`, and the install script checks it. That proves a
+download arrived intact, but not who produced it: anyone who could replace an
+artifact could replace the checksum file beside it.
+
+`SHA256SUMS.sigstore.json` is what proves origin. It is a [Sigstore][sigstore]
+signature over the checksum file, made by the release workflow itself rather than
+by a key any person holds, so verifying it tells you the file was produced by this
+repository's release workflow at this tag. Because every artifact is listed in
+`SHA256SUMS`, verifying that one signature covers the whole release.
+
+With [cosign][cosign] installed:
+
+```bash
+cosign verify-blob \
+  --bundle SHA256SUMS.sigstore.json \
+  --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+  --certificate-identity-regexp '^https://github.com/derekwisong/datui/\.github/workflows/release\.yml@refs/tags/' \
+  SHA256SUMS
+```
+
+Then check the artifacts against the file it just vouched for:
+
+```bash
+sha256sum -c SHA256SUMS
+```
+
+The signing certificate is recorded in Rekor, Sigstore's public transparency log,
+which is what lets you verify without having to trust us to hand you the right key.
+
+[sigstore]: https://www.sigstore.dev/
+[cosign]: https://github.com/sigstore/cosign

--- a/deny.toml
+++ b/deny.toml
@@ -95,6 +95,12 @@ allow = [
     # library with a pure-Rust implementation, which is a straight improvement
     # on a path that parses untrusted input.
     "bzip2-1.0.6",
+    # libfuzzer-sys, in the fuzz/ workspace. NCSA is the University of
+    # Illinois/NCSA Open Source License, which LLVM used before relicensing;
+    # libFuzzer itself is still under it. Permissive and BSD-shaped. It reaches
+    # only the fuzz targets, which are a development tool and are never
+    # published or shipped in a binary.
+    "NCSA",
 ]
 confidence-threshold = 0.8
 

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -9,6 +9,9 @@ name = "datui-fuzz"
 version = "0.0.0"
 publish = false
 edition = "2021"
+# Never published, but cargo-deny audits this tree and an unlicensed crate fails the
+# licence check.
+license = "MIT"
 
 [package.metadata]
 cargo-fuzz = true

--- a/scripts/code/check_security.sh
+++ b/scripts/code/check_security.sh
@@ -14,6 +14,12 @@ cargo deny check
 echo "==> cargo-deny (datui-pyo3)"
 cargo deny --manifest-path crates/datui-pyo3/Cargo.toml check
 
+echo "==> cargo-deny (fuzz)"
+# Its own workspace, like datui-pyo3, so `cargo deny check` above does not reach it and
+# its lockfile would go unaudited. Nothing here ships in a binary, but the advisories
+# still matter for anyone running the fuzzers.
+cargo deny --manifest-path fuzz/Cargo.toml check
+
 echo "==> zizmor (workflow analysis)"
 # --min-severity high matches the CI gate. Drop the flag to see everything.
 zizmor --config zizmor.yml --min-severity high .github/workflows/


### PR DESCRIPTION
Two gaps, both of which OpenSSF Scorecard also flags. Signed-Releases is the largest single check datui fully controls, worth about +0.57 of the overall score on its own.

## Release signing

Releases carried `SHA256SUMS` but no signature, so a download could be checked for integrity but not origin — whoever could replace an artifact could replace the checksum file beside it. The comment on that step already said a signature was "the next step and a separate one".

`SHA256SUMS` is now signed with cosign and the signature published alongside it. Signing the checksum file rather than each artifact is deliberate: it already covers every downloadable by hash, so one signature carries the whole release and there is one thing for a user to verify.

Signing is **keyless**, via Sigstore. There is no private key to hold as a secret, protect, rotate, or lose. The identity is the release workflow's own OIDC token, so the signature attests that this repository's workflow produced the file at this tag — both a stronger and a more checkable claim than "someone with a key did". The publish job already had `id-token: write` for Pages, so no new permission was needed.

`SECURITY.md` now carries the verification command, since a signature nobody knows how to check is decoration:

```bash
cosign verify-blob \
  --bundle SHA256SUMS.sigstore.json \
  --certificate-oidc-issuer https://token.actions.githubusercontent.com \
  --certificate-identity-regexp '^https://github.com/derekwisong/datui/\.github/workflows/release\.yml@refs/tags/' \
  SHA256SUMS
```

Worth knowing: keyless signing publishes the certificate to Rekor, Sigstore's public transparency log. That is public information about a public release, and it is what lets anyone verify without trusting us to serve them the right key.

## The unaudited lockfile

`fuzz/` is its own Cargo workspace — the same arrangement as `datui-pyo3`, for the same reason — so its lockfile was covered by neither cargo-deny invocation and went unaudited from the moment it was committed last week. My oversight in #114. It is now checked in the Security workflow and by `check_security.sh` alongside the other two.

Auditing it immediately turned up two things it had been hiding:

- `datui-fuzz` declared no `license`, which fails the licence check outright.
- `libfuzzer-sys` is NCSA, which was not on the allow list. That is the University of Illinois/NCSA licence LLVM used before relicensing: permissive, BSD-shaped, and reaching only the fuzz targets, which are a development tool that is never published or shipped in a binary.

## Verification

The cosign round trip was tested locally against cosign v3.0.6, the version the pinned installer provides: `--bundle` writes the new Sigstore bundle format, `verify-blob` accepts it, and a tampered blob fails with `invalid signature`. The keyless OIDC path itself cannot be exercised outside CI, so the first signed release is the real test of that half.

All three dependency trees now report `advisories ok, bans ok, licenses ok, sources ok`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WQH4iT4EzArrQjkpisQuG3