### PR TITLE
Put a floor under filelock, and correct the security doc

### DIFF
--- a/docs/for-developers/security-checks.md
+++ b/docs/for-developers/security-checks.md
@@ -12,9 +12,14 @@ gates. Both are in the `Security` workflow, and both can be run locally.
 **cargo-deny** checks `Cargo.lock` against the [RustSec advisory
 database][rustsec], plus licenses, banned and duplicate crates, and the
 registries dependencies come from. It runs against the root workspace and
-against `crates/datui-pyo3`, which is excluded from the workspace and would
-otherwise never be audited. Configuration is in `deny.toml` at the repository
-root.
+against `crates/datui-pyo3` and `fuzz`, both of which are excluded from the
+workspace and would otherwise never be audited. Configuration is in `deny.toml`
+at the repository root.
+
+Nothing audits the Python dependencies in `scripts/`. They are development
+tooling and never reach a datui user, but an advisory in them still reaches a
+contributor's machine, so a version floor with the advisory ids written beside
+it is the current answer.
 
 **zizmor** analyses the GitHub Actions workflow files for the patterns that let
 a pull request steal a secret or poison a build: unpinned actions, over-broad
@@ -57,9 +62,11 @@ things written down: why it is acceptable today, and the event that should clear
 it. An entry without both is a silenced alarm rather than a decision.
 
 The current entries are all of that shape. The two `quick-xml` denial-of-service
-advisories are the ones worth watching: they are reachable whenever datui opens
-an `.xlsx` file, which is untrusted data, and they clear when `calamine` can be
-upgraded past its `quick-xml` 0.38 pin.
+advisories are the ones worth watching. They used to be reachable whenever datui
+opened an `.xlsx` file, which is untrusted data; `calamine` 0.36 moved to
+`quick-xml` 0.41 and closed that path. What is left is the copy `object_store`
+uses to parse S3 and GCS responses, which `polars` pins, so reaching it needs an
+object-store endpoint the user chose that answers with hostile XML.
 
 ## Adding a new action to a workflow
 

--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -11,4 +11,17 @@ jinja2
 # for running the pre-commit hooks
 pre-commit
 
+# Not used directly. pre-commit pulls virtualenv, which pulls filelock, and
+# filelock before 3.20.3 carries two TOCTOU symlink advisories
+# (PYSEC-2026-1374, PYSEC-2026-1375): it checks whether the lock file exists
+# and then opens it with O_TRUNC, so a local attacker who wins the race can
+# point the name at a file of yours and have it truncated.
+#
+# Pip already resolves past this without the floor, because current virtualenv
+# requires filelock >= 3.24.2 on the Python versions datui supports. The floor
+# is here because nothing audits this file, so "it happens to resolve safely
+# today" is not written down anywhere and nothing would notice if it stopped
+# being true. OpenSSF Scorecard reports both advisories against the repository.
+filelock>=3.20.3
+
 # Wheel build deps: requirements-wheel.txt (Linux/macOS), requirements-wheel-windows.txt (Windows)


### PR DESCRIPTION
OpenSSF Scorecard reports seven advisories against this repository. Six of them
have no action available; this addresses the one that does.

## The five Rust advisories

All five are already in `deny.toml` with the event that would clear each one.
Rechecked while writing this, since two of the entries were written before the
upgrades that were supposed to clear them:

| Advisory | Crate | Status |
| --- | --- | --- |
| RUSTSEC-2026-0194/0195 | quick-xml 0.38 | `object_store` 0.13.2 moves only to quick-xml 0.39; the fix is 0.41 |
| RUSTSEC-2025-0134 | rustls-pemfile | dropped by `object_store` 0.13, so a polars upgrade would clear it |
| RUSTSEC-2026-0192 | ttf-parser | `plotters` needs its `ttf` feature to render text in chart exports |
| RUSTSEC-2025-0141 | bincode | no fixed version exists |

The quick-xml entry in `deny.toml` says it clears when polars bumps
`object_store` to something built on quick-xml 0.41. polars 0.53 and later do
raise `object_store` to 0.13, but 0.13.2 is on quick-xml 0.39, so that upgrade
would clear `rustls-pemfile` and leave both denial-of-service advisories in
place. Not worth a polars major upgrade for one unmaintained-crate notice.

`ttf-parser` arrives through `plotters`, which `chart_export.rs` uses with
`BitMapBackend`. Text rendering on that backend is behind the `ttf` feature, so
turning it off would produce chart exports with no title and no axis labels.

## The filelock floor

`PYSEC-2026-1374` and `PYSEC-2026-1375` are against `filelock`, which
`scripts/requirements.txt` reaches through `pre-commit` and `virtualenv`. A
floor at the fixed version is the one thing in this repository that can act on
any of the seven.

Being straight about what it buys: pip already resolves past both advisories
without it, because current `virtualenv` requires `filelock >= 3.24.2` on every
Python version datui supports. Running osv-scanner 2.5.1 locally with
Scorecard's own plugin configuration, over a clean export of this commit,
reports the five RustSec advisories and no filelock at all. So the published
finding does not reproduce here and this may not move the check.

It is still the right line to add. Nothing audits the Python dependency files.
cargo-deny covers three lockfiles and stops there, so this file resolving safely
is an accident nobody wrote down and nothing would notice stopping. The floor
writes it down, with the advisory ids beside it.

## Doc corrections

`docs/for-developers/security-checks.md` had two stale claims. The cargo-deny
section predates `fuzz/` being audited in #115, and the paragraph on the
quick-xml advisories still says they are reachable through `.xlsx`, which #79
fixed by moving calamine to 0.36. `deny.toml` has the current reasoning; the doc
had the old.

## Follow-up, not in this PR

Nothing checks `scripts/requirements*.txt` on any schedule. Adding `pip-audit`
to the Security workflow would catch the next one of these when it lands rather
than when Scorecard next runs. Happy to do it if you want the job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015XaEL6hbCPSZ4cw4cR9R4r
