### PR TITLE
Add CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,15 @@
+# Contributing
+
+Contributions are welcome. Everything you need is in the
+[developer guide](https://derekwisong.github.io/datui/latest/for-developers/contributing.html),
+source at [docs/for-developers/contributing.md](docs/for-developers/contributing.md):
+setup, tests, what the pre-commit hooks enforce, and how changes land.
+
+Bugs and feature requests go to
+[the issue tracker](https://github.com/derekwisong/datui/issues).
+
+A suspected vulnerability does not. [SECURITY.md](SECURITY.md) has the private
+channel and the scope.
+
+datui is MIT licensed; see [LICENSE](LICENSE). Contributions are accepted under
+the same terms.


### PR DESCRIPTION
The content already exists in `docs/for-developers`, but not where a contributor looks for it. GitHub's new-contributor prompts read a file at the root or under `.github`, and so do the OpenSSF Best Practices badge criteria.

So this is a signpost, not a second copy. Four links: the developer guide, the issue tracker, `SECURITY.md` for anything that should not be a public issue, and the licence. Anything explained here would duplicate the guide, and the duplicate is the copy that goes stale.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015XaEL6hbCPSZ4cw4cR9R4r